### PR TITLE
Doc out of scope

### DIFF
--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -7,13 +7,15 @@ use std::ffi::{CString};
 
 ///The xpath context
 #[derive(Clone)]
-pub struct Context {
+pub struct Context<'a> {
     ///libxml's `ContextPtr`
     pub context_ptr : *mut c_void,
+    ///Document contains pointer, needed for ContextPtr, so we need to borrow Document to prevent it's freeing
+    pub document: &'a Document, 
 }
 
 
-impl Drop for Context {
+impl<'a> Drop for Context<'a> {
     ///free xpath context when it goes out of scope
     fn drop(&mut self) {
         unsafe {
@@ -30,7 +32,7 @@ pub struct Object {
 }
 
 
-impl Context {
+impl<'a> Context<'a> {
     ///create the xpath context for a document
     pub fn new(doc : &Document) -> Result<Context, ()> {
         let ctxtptr : *mut c_void = unsafe {
@@ -38,7 +40,7 @@ impl Context {
         if ctxtptr.is_null() {
             Err(())
         } else {
-            Ok(Context {context_ptr : ctxtptr })
+            Ok(Context {context_ptr : ctxtptr, document: doc })
         }
     }
     ///evaluate an xpath

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -173,19 +173,6 @@ fn test_class_names() {
 }
 
 #[test]
-/// Test that context::evaluate will work if document will go out of scope
-fn test_context_without_document() {
-  let context: Context;
-  {	
-    let doc = Parser::default_html().parse_file("tests/resources/file01.xml").unwrap();
-    context = Context::new(&doc).unwrap();
-  }
-
-  let p = context.evaluate("//child").unwrap();
-  assert_eq!(p.get_number_of_nodes(), 2);
-}
-
-#[test]
 /// Test well-formedness of a Rust string
 /// IMPORTANT: Currenlty NOT THREAD-SAFE, use in single-threaded apps only!
 fn test_well_formed_html() {

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -173,6 +173,19 @@ fn test_class_names() {
 }
 
 #[test]
+/// Test that context::evaluate will work if document will go out of scope
+fn test_context_without_document() {
+  let context: Context;
+  {	
+    let doc = Parser::default_html().parse_file("tests/resources/file01.xml").unwrap();
+    context = Context::new(&doc).unwrap();
+  }
+
+  let p = context.evaluate("//child").unwrap();
+  assert_eq!(p.get_number_of_nodes(), 2);
+}
+
+#[test]
 /// Test well-formedness of a Rust string
 /// IMPORTANT: Currenlty NOT THREAD-SAFE, use in single-threaded apps only!
 fn test_well_formed_html() {


### PR DESCRIPTION
First commit has test, which demonstrates segmentation fault, second commit fixes error and makes that test impossible to compile, so test is removed in second commit. This change also makes #8 impossible to compile, so that was the real cause of problem there.