### PR TITLE
Use the same options for parse_string() as in parse_file()

### DIFF
--- a/src/c_signatures.rs
+++ b/src/c_signatures.rs
@@ -47,9 +47,10 @@ extern "C" {
   pub fn xmlReadFile(filename: *const c_char, encoding: *const c_char, options: c_uint) -> *mut c_void;
   // pub fn htmlParseFile(filename: *const c_char, encoding: *const c_char) -> *mut c_void;
   pub fn htmlReadFile(filename: *const c_char, encoding: *const c_char, options: c_uint) -> *mut c_void;
-  // pub fn htmlReadDoc(html_string: *const c_char, url: *const c_char, encoding: *const c_char, options: c_uint) -> *mut c_void;
-  pub fn xmlParseDoc(xml_string: *const c_char) -> *mut c_void;
-  pub fn htmlParseDoc(xml_string: *const c_char, encoding: *const c_char) -> *mut c_void;
+  pub fn htmlReadDoc(html_string: *const c_char, url: *const c_char, encoding: *const c_char, options: c_uint) -> *mut c_void;
+  pub fn xmlReadDoc(xml_string: *const c_char, url: *const c_char, encoding: *const c_char, options: c_uint) -> *mut c_void;
+  // pub fn xmlParseDoc(xml_string: *const c_char) -> *mut c_void;
+  // pub fn htmlParseDoc(xml_string: *const c_char, encoding: *const c_char) -> *mut c_void;
   pub fn htmlNewParserCtxt() -> *mut c_void;
   pub fn htmlCtxtReadDoc(ctxt: *mut c_void, html_string: *const c_char, url: *mut c_void, encoding: *const c_char, options: c_uint) -> *mut c_void;
   // pub fn htmlSAXParseDoc(xml_string: *const c_char, encoding: *const c_char, sax: *mut c_void, user_data: *mut c_void) -> *mut c_void;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -113,15 +113,22 @@ impl Parser {
   pub fn parse_string(&self, input_string: &str) -> Result<Document, XmlParseError> {
     let c_string = CString::new(input_string).unwrap();
     let c_utf8 = CString::new("utf-8").unwrap();
+    let c_url = CString::new("").unwrap();
     match self.format {
       ParseFormat::XML => { unsafe {
-        let docptr = xmlParseDoc(c_string.as_ptr());
+        let options : u32 = XmlParserOption::XmlParseRecover as u32 +
+                            XmlParserOption::XmlParseNoerror as u32 +
+                            XmlParserOption::XmlParseNowarning as u32;
+        let docptr = xmlReadDoc(c_string.as_ptr(), c_url.as_ptr(), c_utf8.as_ptr(), options);
         match docptr.is_null() {
           true => Err(XmlParseError::GotNullPointer),
           false => Ok(Document::new_ptr(docptr))
         } } },
       ParseFormat::HTML => { unsafe {
-        let docptr = htmlParseDoc(c_string.as_ptr(), c_utf8.as_ptr());
+        let options : u32 = HtmlParserOption::HtmlParseRecover as u32 +
+                            HtmlParserOption::HtmlParseNoerror as u32 +
+                            HtmlParserOption::HtmlParseNowarning as u32;
+        let docptr = htmlReadDoc(c_string.as_ptr(), c_url.as_ptr(), c_utf8.as_ptr(), options);
         match docptr.is_null() {
           true => Err(XmlParseError::GotNullPointer),
           false => Ok(Document::new_ptr(docptr))


### PR DESCRIPTION
This is mainly for suppressing warnings, which libxml write to stderr, they really on the way in console application.