### PR TITLE
Add ability to recursively remove ns

### DIFF
--- a/src/c_signatures.rs
+++ b/src/c_signatures.rs
@@ -66,7 +66,7 @@ extern "C" {
   pub fn xmlDocDumpFormatMemoryEnc(doc: *mut c_void, receiver: *mut *mut c_char, size: *const c_int, encoding: *const c_char, format: c_int);
   pub fn setIndentTreeOutput(indent: c_int);
   pub fn getIndentTreeOutput() -> c_int;
-
+  pub fn xmlNodeRecursivelyRemoveNs(node: *mut c_void);
   // parser
   pub fn xmlReadFile(filename: *const c_char, encoding: *const c_char, options: c_uint) -> *mut c_void;
   // pub fn htmlParseFile(filename: *const c_char, encoding: *const c_char) -> *mut c_void;

--- a/src/helper_functions.c
+++ b/src/helper_functions.c
@@ -76,6 +76,33 @@ int getIndentTreeOutput() {
   return xmlIndentTreeOutput;
 }
 
+// Taken from Nokogiri (https://github.com/sparklemotion/nokogiri/blob/24bb843327306d2d71e4b2dc337c1e327cbf4516/ext/nokogiri/xml_document.c#L64)
+void xmlNodeRecursivelyRemoveNs(xmlNodePtr node)
+{
+  xmlNodePtr child ;
+  xmlAttrPtr property ;
+
+  xmlSetNs(node, NULL);
+
+  for (child = node->children ; child ; child = child->next)
+    xmlNodeRecursivelyRemoveNs(child);
+
+  if (((node->type == XML_ELEMENT_NODE) ||
+       (node->type == XML_XINCLUDE_START) ||
+       (node->type == XML_XINCLUDE_END)) &&
+      node->nsDef) {
+    xmlFreeNsList(node->nsDef);
+    node->nsDef = NULL;
+  }
+
+  if (node->type == XML_ELEMENT_NODE && node->properties != NULL) {
+    property = node->properties ;
+    while (property != NULL) {
+      if (property->ns) property->ns = NULL ;
+      property = property->next ;
+    }
+  }
+}
 
 /*
  * helper functions for xpath

--- a/src/helper_functions.h
+++ b/src/helper_functions.h
@@ -63,6 +63,7 @@ const char * xmlNodeGetContentPointer(const xmlNodePtr cur);
 void setIndentTreeOutput(const int indent);
 int getIndentTreeOutput();
 
+void xmlNodeRecursivelyRemoveNs(xmlNodePtr node);
 
 /*
  * helper functions for xpath

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -645,6 +645,11 @@ impl Node {
     }
   }
 
+  /// Removes the namespaces of this `Node` and it's children!
+  pub fn recursively_remove_namespaces(&mut self) {
+    unsafe { xmlNodeRecursivelyRemoveNs(self.node_ptr) }
+  }
+
   /// Get a set of class names from this node's attributes
   pub fn get_class_names(&self) -> HashSet<String> {
     let mut set = HashSet::new();

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -334,6 +334,14 @@ fn xpath_with_namespaces() {
   assert_eq!(result_all.get_number_of_nodes(), 12);
   assert_eq!(result_all.get_nodes_as_vec().len(), 12);
 
+  let result_h_table = context.evaluate("//table").unwrap();
+  assert_eq!(result_h_table.get_number_of_nodes(), 0);
+  assert_eq!(result_h_table.get_nodes_as_vec().len(), 0);
+
+  doc.as_node().recursively_remove_namespaces();
+  let result_h_table = context.evaluate("//table").unwrap();
+  assert_eq!(result_h_table.get_number_of_nodes(), 2);
+  assert_eq!(result_h_table.get_nodes_as_vec().len(), 2);
 }
 
 #[test]


### PR DESCRIPTION
Coming from ruby I've loved to use Nokogiri, so now that I'm porting some code I found that this wasn't in libxml but in Nokogiri but still think it is useful.

From the Nokogiri docs

> This could be useful for developers who either don't understand namespaces
or don't care about them.