### PR TITLE
Add attribute for gcc about unused variable

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@
 extern crate gcc;
 
 fn main() {
-  gcc::Config::new()
+  gcc::Build::new()
     .file("src/helper_functions.c")
     .include("/usr/include/libxml2")
     .compile("libhelper_functions.a");

--- a/src/helper_functions.c
+++ b/src/helper_functions.c
@@ -138,7 +138,7 @@ int htmlWellFormed(htmlParserCtxtPtr ctxt) {
 }
 
 // dummy function: no debug output at all
-void _ignoreInvalidTagsErrorFunc(void * userData, xmlErrorPtr error) {
+void _ignoreInvalidTagsErrorFunc(void * userData __attribute__ ((unused)), xmlErrorPtr error) {
   if ((error != NULL) && (error->code == XML_HTML_UNKNOWN_TAG)) { // do not record invalid, in fact (out of despair) claim we ARE well-formed, when a tag is invalid.
     hacky_well_formed = 1;
   }


### PR DESCRIPTION
As I'm using a local repo I get a warning each time I compile, this silence that warning a alas doesn't clobber my tiny console output.