### PR TITLE
rustfmt, clippy suggestions

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+# Detailed instructions at: https://github.com/rust-lang-nursery/rustfmt/blob/master/Configurations.md
+tab_spaces = 2

--- a/src/c_signatures.rs
+++ b/src/c_signatures.rs
@@ -10,12 +10,27 @@ extern "C" {
   pub fn xmlFreeDoc(cur: *mut c_void);
   // pub fn xmlFree(name : *const c_char);
   // pub fn xmlNewNode(ns : *mut c_void, name: *const c_char) -> *mut c_void;
-  pub fn xmlNewDocNode(doc: *mut c_void, ns: *mut c_void, name: *const c_char, content: *const c_char) -> *mut c_void;
+  pub fn xmlNewDocNode(
+    doc: *mut c_void,
+    ns: *mut c_void,
+    name: *const c_char,
+    content: *const c_char,
+  ) -> *mut c_void;
   pub fn xmlNewDocText(doc: *mut c_void, content: *const c_char) -> *mut c_void;
   // pub fn xmlFreeNode(cur: *mut c_void);
   pub fn xmlNewNs(node: *mut c_void, href: *const c_char, prefix: *const c_char) -> *mut c_void;
-  pub fn xmlNewChild(parent: *mut c_void, ns: *mut c_void, name: *const c_char, content: *const c_char) -> *mut c_void;
-  pub fn xmlNewTextChild(parent: *mut c_void, ns: *mut c_void, name: *const c_char, content: *const c_char) -> *mut c_void;
+  pub fn xmlNewChild(
+    parent: *mut c_void,
+    ns: *mut c_void,
+    name: *const c_char,
+    content: *const c_char,
+  ) -> *mut c_void;
+  pub fn xmlNewTextChild(
+    parent: *mut c_void,
+    ns: *mut c_void,
+    name: *const c_char,
+    content: *const c_char,
+  ) -> *mut c_void;
   // pub fn xmlNewText(parent: *mut c_void, content: *const c_char) -> *mut c_void;
   pub fn xmlNewDocPI(doc: *mut c_void, name: *const c_char, content: *const c_char) -> *mut c_void;
   // pub fn xmlFreeNs(cur: *mut c_void);
@@ -23,16 +38,26 @@ extern "C" {
   pub fn xmlDocGetRootElement(doc: *const c_void) -> *mut c_void;
   pub fn xmlDocSetRootElement(doc: *const c_void, root: *const c_void) -> *mut c_void;
   pub fn xmlGetProp(node: *const c_void, name: *const c_char) -> *const c_char;
-  pub fn xmlSetProp(node: *const c_void, name: *const c_char, value: *const c_char) -> *const c_char;
+  pub fn xmlSetProp(
+    node: *const c_void,
+    name: *const c_char,
+    value: *const c_char,
+  ) -> *const c_char;
   pub fn xmlHasProp(node: *const c_void, name: *const c_char) -> *mut c_void;
   pub fn xmlRemoveProp(attr_node: *const c_void) -> c_int;
-  pub fn xmlGetNsProp(node: *const c_void, name: *const c_char, ns: *const c_char) -> *const c_char;
+  pub fn xmlGetNsProp(node: *const c_void, name: *const c_char, ns: *const c_char)
+    -> *const c_char;
   pub fn xmlGetFirstProperty(node: *const c_void) -> *mut c_void;
   pub fn xmlNextPropertySibling(attr: *const c_void) -> *mut c_void;
   pub fn xmlAttrName(attr: *const c_void) -> *const c_char;
   pub fn xmlGetNsList(doc: *const c_void, node: *const c_void) -> *const *mut c_void;
   pub fn xmlSetNs(node: *const c_void, ns: *const c_void);
-  pub fn xmlSetNsProp(node: *const c_void, ns: *const c_void, name: *const c_char, value: *const c_char);
+  pub fn xmlSetNsProp(
+    node: *const c_void,
+    ns: *const c_void,
+    name: *const c_char,
+    value: *const c_char,
+  );
   pub fn xmlNsPrefix(ns: *const c_void) -> *const c_char;
   pub fn xmlNsHref(ns: *const c_void) -> *const c_char;
   pub fn xmlCopyNamespace(ns: *const c_void) -> *mut c_void;
@@ -57,7 +82,13 @@ extern "C" {
   pub fn xmlBufferCreate() -> *mut c_void;
   pub fn xmlBufferFree(buf: *mut c_void);
   pub fn xmlBufferContent(buf: *mut c_void) -> *const c_char;
-  pub fn xmlNodeDump(buf: *mut c_void, doc: *mut c_void, node: *mut c_void, indent: c_int, disable_format: c_int);
+  pub fn xmlNodeDump(
+    buf: *mut c_void,
+    doc: *mut c_void,
+    node: *mut c_void,
+    indent: c_int,
+    disable_format: c_int,
+  );
   pub fn xmlNodeNsDeclarations(cur: *const c_void) -> *mut c_void;
   pub fn xmlNodeNs(cur: *const c_void) -> *mut c_void;
   pub fn xmlNextNsSibling(attr: *const c_void) -> *mut c_void;
@@ -65,21 +96,57 @@ extern "C" {
   pub fn xmlDocCopyNode(node: *const c_void, doc: *const c_void, extended: c_int) -> *mut c_void;
   pub fn xmlCopyDoc(doc: *mut c_void, recursive: c_int) -> *mut c_void;
   // pub fn xmlDocDumpMemory(doc: *mut c_void, receiver: *mut *mut c_char, size: *const c_int, format: c_int );
-  pub fn xmlDocDumpMemoryEnc(doc: *mut c_void, receiver: *mut *mut c_char, size: *const c_int, encoding: *const c_char, format: c_int);
-  pub fn xmlDocDumpFormatMemoryEnc(doc: *mut c_void, receiver: *mut *mut c_char, size: *const c_int, encoding: *const c_char, format: c_int);
+  pub fn xmlDocDumpMemoryEnc(
+    doc: *mut c_void,
+    receiver: *mut *mut c_char,
+    size: *const c_int,
+    encoding: *const c_char,
+    format: c_int,
+  );
+  pub fn xmlDocDumpFormatMemoryEnc(
+    doc: *mut c_void,
+    receiver: *mut *mut c_char,
+    size: *const c_int,
+    encoding: *const c_char,
+    format: c_int,
+  );
   pub fn setIndentTreeOutput(indent: c_int);
   pub fn getIndentTreeOutput() -> c_int;
   pub fn xmlNodeRecursivelyRemoveNs(node: *mut c_void);
   // parser
-  pub fn xmlReadFile(filename: *const c_char, encoding: *const c_char, options: c_uint) -> *mut c_void;
+  pub fn xmlReadFile(
+    filename: *const c_char,
+    encoding: *const c_char,
+    options: c_uint,
+  ) -> *mut c_void;
   // pub fn htmlParseFile(filename: *const c_char, encoding: *const c_char) -> *mut c_void;
-  pub fn htmlReadFile(filename: *const c_char, encoding: *const c_char, options: c_uint) -> *mut c_void;
-  pub fn htmlReadDoc(html_string: *const c_char, url: *const c_char, encoding: *const c_char, options: c_uint) -> *mut c_void;
-  pub fn xmlReadDoc(xml_string: *const c_char, url: *const c_char, encoding: *const c_char, options: c_uint) -> *mut c_void;
+  pub fn htmlReadFile(
+    filename: *const c_char,
+    encoding: *const c_char,
+    options: c_uint,
+  ) -> *mut c_void;
+  pub fn htmlReadDoc(
+    html_string: *const c_char,
+    url: *const c_char,
+    encoding: *const c_char,
+    options: c_uint,
+  ) -> *mut c_void;
+  pub fn xmlReadDoc(
+    xml_string: *const c_char,
+    url: *const c_char,
+    encoding: *const c_char,
+    options: c_uint,
+  ) -> *mut c_void;
   // pub fn xmlParseDoc(xml_string: *const c_char) -> *mut c_void;
   // pub fn htmlParseDoc(xml_string: *const c_char, encoding: *const c_char) -> *mut c_void;
   pub fn htmlNewParserCtxt() -> *mut c_void;
-  pub fn htmlCtxtReadDoc(ctxt: *mut c_void, html_string: *const c_char, url: *mut c_void, encoding: *const c_char, options: c_uint) -> *mut c_void;
+  pub fn htmlCtxtReadDoc(
+    ctxt: *mut c_void,
+    html_string: *const c_char,
+    url: *mut c_void,
+    encoding: *const c_char,
+    options: c_uint,
+  ) -> *mut c_void;
   // pub fn htmlSAXParseDoc(xml_string: *const c_char, encoding: *const c_char, sax: *mut c_void, user_data: *mut c_void) -> *mut c_void;
   pub fn xmlInitParser();
   pub fn xmlCleanupParser();
@@ -98,10 +165,12 @@ extern "C" {
   pub fn xmlXPathNewContext(doc: *mut c_void) -> *mut c_void;
   pub fn xmlXPathEvalExpression(str: *const c_char, ctxt: *mut c_void) -> *mut c_void;
   pub fn xmlXPathCastToString(val: *const c_void) -> *const c_char;
-  pub fn xmlXPathRegisterNs(ctxt: *mut c_void, prefix: *const c_char, href: *const c_char) -> c_int;
+  pub fn xmlXPathRegisterNs(ctxt: *mut c_void, prefix: *const c_char, href: *const c_char)
+    -> c_int;
   pub fn xmlXPathSetContextNode(node: *mut c_void, ctxt: *mut c_void) -> c_int;
-  pub fn xmlSearchNsByHref(doc: *mut c_void, node: *mut c_void, href: *const c_char) -> *mut c_void;
-  pub fn xmlSearchNs( doc: *mut c_void, node: *mut c_void, prefix: *const c_char ) -> *mut c_void;
+  pub fn xmlSearchNsByHref(doc: *mut c_void, node: *mut c_void, href: *const c_char)
+    -> *mut c_void;
+  pub fn xmlSearchNs(doc: *mut c_void, node: *mut c_void, prefix: *const c_char) -> *mut c_void;
   // helper for xpath
   pub fn xmlXPathObjectNumberOfNodes(val: *const c_void) -> c_int;
   pub fn xmlXPathObjectGetNode(val: *const c_void, index: size_t) -> *mut c_void;

--- a/src/global.rs
+++ b/src/global.rs
@@ -6,33 +6,30 @@ static mut LIBXML_OBJECTS: i64 = 0;
 
 /// Initializes the global libxml2 context once, before the first libxml2 object allocation
 pub fn _libxml_global_init() {
-    with_lock(||
-        unsafe {
-          if LIBXML_OBJECTS == 0 {
-              xmlInitParser();
-              xmlInitGlobals();
-          }
-          LIBXML_OBJECTS += 1;
-        }
-    );
+  with_lock(|| unsafe {
+    if LIBXML_OBJECTS == 0 {
+      xmlInitParser();
+      xmlInitGlobals();
+    }
+    LIBXML_OBJECTS += 1;
+  });
 }
 
 /// Currently a no-op use `force_global_drop` instead.
 pub fn _libxml_global_drop() {
-    with_lock(||
-        unsafe {
-          if LIBXML_OBJECTS == 1 { // Far from perfect, more "desperate" than anything...
-              // The big issue here is taht calling these deallocations causes segfaults
-              // if any thread is still using libxml2 constructs. And Rust doesn't give us a good hook for "end of static scope",
-              // hence we're sunk... For now uncommenting here and leaving a "libxml_force_global_drop()" for manual use...
-              //  ... very unsatisfying
+  with_lock(|| unsafe {
+    if LIBXML_OBJECTS == 1 {
+      // Far from perfect, more "desperate" than anything...
+      // The big issue here is taht calling these deallocations causes segfaults
+      // if any thread is still using libxml2 constructs. And Rust doesn't give us a good hook for "end of static scope",
+      // hence we're sunk... For now uncommenting here and leaving a "libxml_force_global_drop()" for manual use...
+      //  ... very unsatisfying
 
-              //xmlCleanupGlobals();
-              //xmlCleanupParser();
-          }
-          LIBXML_OBJECTS -= 1;
-        }
-  );
+      //xmlCleanupGlobals();
+      //xmlCleanupParser();
+    }
+    LIBXML_OBJECTS -= 1;
+  });
 }
 
 /// Forces a drop of global libxml2 context. Only invoke after all threads using libxml2 are finished.
@@ -44,9 +41,12 @@ pub fn force_global_drop() {
 }
 
 /// Helper lock mechanism, to allow for safe global libxml2 init/drop
-fn with_lock<F>(thunk: F) where F: Fn() {
-    static LIBXML_LOCK: AtomicBool = ATOMIC_BOOL_INIT;
-    while LIBXML_LOCK.compare_and_swap(false, true, Ordering::SeqCst) {}
-    thunk();
-    LIBXML_LOCK.store(false, Ordering::SeqCst);
+fn with_lock<F>(thunk: F)
+where
+  F: Fn(),
+{
+  static LIBXML_LOCK: AtomicBool = ATOMIC_BOOL_INIT;
+  while LIBXML_LOCK.compare_and_swap(false, true, Ordering::SeqCst) {}
+  thunk();
+  LIBXML_LOCK.store(false, Ordering::SeqCst);
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,49 +4,49 @@ use c_signatures::*;
 use global::*;
 use tree::*;
 
-use std::ffi::{CStr,CString};
+use std::ffi::{CStr, CString};
 use std::fmt;
 use std::ptr;
 use std::str;
 
 enum XmlParserOption {
-    Recover = 1, // Relaxed parsing
-    // XML_PARSE_NODEFDTD = 4, // do not default a doctype if not found
-    Noerror = 32, // suppress error reports
-    Nowarning = 64, // suppress warning reports
-    // XML_PARSE_PEDANTIC = 128, // pedantic error reporting
-    // XML_PARSE_NOBLANKS = 256, // remove blank nodes
-    // XML_PARSE_NONET = 2048, // Forbid network access
-    // XML_PARSE_NOIMPLIED = 8192, // Do not add implied Xml/body... elements
-    // XML_PARSE_COMPACT = 65536, // compact small text nodes
-    // XML_PARSE_IGNORE_ENC = 2097152, // ignore internal document encoding hint
+  Recover = 1, // Relaxed parsing
+  // XML_PARSE_NODEFDTD = 4, // do not default a doctype if not found
+  Noerror = 32, // suppress error reports
+  Nowarning = 64, // suppress warning reports
+                  // XML_PARSE_PEDANTIC = 128, // pedantic error reporting
+                  // XML_PARSE_NOBLANKS = 256, // remove blank nodes
+                  // XML_PARSE_NONET = 2048, // Forbid network access
+                  // XML_PARSE_NOIMPLIED = 8192, // Do not add implied Xml/body... elements
+                  // XML_PARSE_COMPACT = 65536, // compact small text nodes
+                  // XML_PARSE_IGNORE_ENC = 2097152, // ignore internal document encoding hint
 }
 
 enum HtmlParserOption {
-    Recover = 1, // Relaxed parsing
-    // HTML_PARSE_NODEFDTD = 4, // do not default a doctype if not found
-    Noerror = 32, // suppress error reports
-    Nowarning = 64, // suppress warning reports
-    // HTML_PARSE_PEDANTIC = 128, // pedantic error reporting
-    // HTML_PARSE_NOBLANKS = 256, // remove blank nodes
-    // HTML_PARSE_NONET = 2048, // Forbid network access
-    // HTML_PARSE_NOIMPLIED = 8192, // Do not add implied html/body... elements
-    // HTML_PARSE_COMPACT = 65536, // compact small text nodes
-    // HTML_PARSE_IGNORE_ENC = 2097152, // ignore internal document encoding hint
+  Recover = 1, // Relaxed parsing
+  // HTML_PARSE_NODEFDTD = 4, // do not default a doctype if not found
+  Noerror = 32, // suppress error reports
+  Nowarning = 64, // suppress warning reports
+                  // HTML_PARSE_PEDANTIC = 128, // pedantic error reporting
+                  // HTML_PARSE_NOBLANKS = 256, // remove blank nodes
+                  // HTML_PARSE_NONET = 2048, // Forbid network access
+                  // HTML_PARSE_NOIMPLIED = 8192, // Do not add implied html/body... elements
+                  // HTML_PARSE_COMPACT = 65536, // compact small text nodes
+                  // HTML_PARSE_IGNORE_ENC = 2097152, // ignore internal document encoding hint
 }
 
 ///Parser Errors
 pub enum XmlParseError {
-    ///Parsing returned a null pointer as document pointer
-    GotNullPointer,
+  ///Parsing returned a null pointer as document pointer
+  GotNullPointer,
 }
 
 impl fmt::Debug for XmlParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            XmlParseError::GotNullPointer => write!(f, "Got a Null pointer")
-        }
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    match *self {
+      XmlParseError::GotNullPointer => write!(f, "Got a Null pointer"),
     }
+  }
 }
 
 #[derive(PartialEq)]
@@ -55,50 +55,48 @@ pub enum ParseFormat {
   /// Strict parsing for XML
   XML,
   /// Relaxed parsing for HTML
-  HTML
+  HTML,
 }
 /// Parsing API wrapper for libxml2
 pub struct Parser {
   /// The `ParseFormat` for this parser
-  pub format : ParseFormat
+  pub format: ParseFormat,
 }
 impl Default for Parser {
   /// Create a parser for XML documents
   fn default() -> Self {
     _libxml_global_init();
-    Parser { format : ParseFormat::XML}
+    Parser { format: ParseFormat::XML }
   }
 }
 impl Parser {
   /// Create a parser for HTML documents
   pub fn default_html() -> Self {
     _libxml_global_init();
-    Parser { format : ParseFormat::HTML}
+    Parser { format: ParseFormat::HTML }
   }
 
   ///Parses the XML/HTML file `filename` to generate a new `Document`
-  pub fn parse_file(&self, filename : &str) -> Result<Document, XmlParseError> {
+  pub fn parse_file(&self, filename: &str) -> Result<Document, XmlParseError> {
     let c_filename = CString::new(filename).unwrap();
     let c_utf8 = CString::new("utf-8").unwrap();
-    let options : u32 = XmlParserOption::Recover as u32 +
-                        XmlParserOption::Noerror as u32 +
-                        XmlParserOption::Nowarning as u32;
+    let options: u32 = XmlParserOption::Recover as u32 + XmlParserOption::Noerror as u32 +
+      XmlParserOption::Nowarning as u32;
     match self.format {
-      ParseFormat::XML => { unsafe {
+      ParseFormat::XML => unsafe {
         xmlKeepBlanksDefault(1);
         let docptr = xmlReadFile(c_filename.as_ptr(), c_utf8.as_ptr(), options);
         if docptr.is_null() {
           Err(XmlParseError::GotNullPointer)
         } else {
           Ok(Document::new_ptr(docptr))
-        } }
+        }
       },
       ParseFormat::HTML => {
         // TODO: Allow user-specified options later on
         unsafe {
-          let options : u32 = HtmlParserOption::Recover as u32 +
-                              HtmlParserOption::Noerror as u32 +
-                              HtmlParserOption::Nowarning as u32;
+          let options: u32 = HtmlParserOption::Recover as u32 + HtmlParserOption::Noerror as u32 +
+            HtmlParserOption::Nowarning as u32;
           xmlKeepBlanksDefault(1);
           let docptr = htmlReadFile(c_filename.as_ptr(), c_utf8.as_ptr(), options);
           if docptr.is_null() {
@@ -117,27 +115,26 @@ impl Parser {
     let c_utf8 = CString::new("utf-8").unwrap();
     let c_url = CString::new("").unwrap();
     match self.format {
-      ParseFormat::XML => { unsafe {
-        let options : u32 = XmlParserOption::Recover as u32 +
-                            XmlParserOption::Noerror as u32 +
-                            XmlParserOption::Nowarning as u32;
+      ParseFormat::XML => unsafe {
+        let options: u32 = XmlParserOption::Recover as u32 + XmlParserOption::Noerror as u32 +
+          XmlParserOption::Nowarning as u32;
         let docptr = xmlReadDoc(c_string.as_ptr(), c_url.as_ptr(), c_utf8.as_ptr(), options);
         if docptr.is_null() {
           Err(XmlParseError::GotNullPointer)
         } else {
           Ok(Document::new_ptr(docptr))
-        } } },
-      ParseFormat::HTML => { unsafe {
-        let options : u32 = HtmlParserOption::Recover as u32 +
-                            HtmlParserOption::Noerror as u32 +
-                            HtmlParserOption::Nowarning as u32;
+        }
+      },
+      ParseFormat::HTML => unsafe {
+        let options: u32 = HtmlParserOption::Recover as u32 + HtmlParserOption::Noerror as u32 +
+          HtmlParserOption::Nowarning as u32;
         let docptr = htmlReadDoc(c_string.as_ptr(), c_url.as_ptr(), c_utf8.as_ptr(), options);
         if docptr.is_null() {
           Err(XmlParseError::GotNullPointer)
         } else {
           Ok(Document::new_ptr(docptr))
         }
-      }}
+      },
     }
   }
 
@@ -148,7 +145,7 @@ impl Parser {
   /// Help is welcome in implementing it correctly.
   pub fn is_well_formed_html(&self, input_string: &str) -> bool {
     if input_string.is_empty() {
-      return false
+      return false;
     }
     let c_string = CString::new(input_string).unwrap();
     let c_utf8 = CString::new("utf-8").unwrap();
@@ -158,7 +155,13 @@ impl Parser {
       ParseFormat::HTML => unsafe {
         let ctxt = htmlNewParserCtxt();
         setWellFormednessHandler(ctxt);
-        let docptr = htmlCtxtReadDoc(ctxt, c_string.as_ptr(), ptr::null_mut(), c_utf8.as_ptr(), 10596); // htmlParserOption = 4+32+64+256+2048+8192
+        let docptr = htmlCtxtReadDoc(
+          ctxt,
+          c_string.as_ptr(),
+          ptr::null_mut(),
+          c_utf8.as_ptr(),
+          10_596,
+        ); // htmlParserOption = 4+32+64+256+2048+8192
         let is_well_formed = htmlWellFormed(ctxt);
         let well_formed_final = if is_well_formed > 0 {
           // Basic well-formedness passes, let's check if we have an <html> element as root too
@@ -166,7 +169,9 @@ impl Parser {
             let node_ptr = xmlDocGetRootElement(docptr);
             let name_ptr = xmlNodeGetName(node_ptr);
             if name_ptr.is_null() {
-              false }  //empty string
+              false
+            }
+            //empty string
             else {
               let c_root_name = CStr::from_ptr(name_ptr);
               let root_name = str::from_utf8(c_root_name.to_bytes()).unwrap().to_owned();
@@ -186,7 +191,7 @@ impl Parser {
           xmlFreeDoc(docptr);
         }
         well_formed_final
-      }
+      },
     }
   }
 }

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -53,11 +53,7 @@ impl<'a> Context<'a> {
     let c_href = CString::new(href).unwrap();
     unsafe {
       let result = xmlXPathRegisterNs(self.context_ptr, c_prefix.as_ptr(), c_href.as_ptr());
-      if result != 0 {
-        Err(())
-      } else {
-        Ok(())
-      }
+      if result != 0 { Err(()) } else { Ok(()) }
     }
   }
 
@@ -77,7 +73,7 @@ impl<'a> Context<'a> {
     unsafe {
       let result = xmlXPathSetContextNode(node.node_ptr, self.context_ptr);
       if result != 0 {
-        return Err(())
+        return Err(());
       }
     }
     Ok(())
@@ -100,7 +96,6 @@ impl<'a> Context<'a> {
     let evaluated = try!(self.evaluate(xpath));
     Ok(evaluated.to_string())
   }
-
 }
 
 impl Drop for Object {
@@ -138,7 +133,7 @@ impl Object {
       if ptr.is_null() {
         panic!("rust-libxml: xpath: found null pointer result set");
       }
-      vec.push(Node { node_ptr: ptr });//node_is_inserted : true
+      vec.push(Node { node_ptr: ptr }); //node_is_inserted : true
     }
     vec
   }

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -25,7 +25,7 @@ fn hello_builder() {
   assert!(hello_element_result.is_ok());
   let mut hello_element = hello_element_result.unwrap();
 
-  doc.set_root_element(&mut hello_element);
+  doc.set_root_element(&hello_element);
 
   hello_element.set_content("world!");
 
@@ -114,13 +114,13 @@ fn child_of_root_has_different_hash() {
     if let Some(child) = root.get_first_child() {
       assert!(root != child);
     } else {
-      assert!(false);   //test failed - child doesn't exist
+      assert!(false); //test failed - child doesn't exist
     }
     // same check with last child
     if let Some(child) = root.get_last_child() {
       assert!(root != child);
     } else {
-      assert!(false);   //test failed - child doesn't exist
+      assert!(false); //test failed - child doesn't exist
     }
   }
 }
@@ -131,8 +131,8 @@ fn node_sibling_accessors() {
   let mut doc = Document::new().unwrap();
   let hello_element_result = Node::new("hello", None, &doc);
   assert!(hello_element_result.is_ok());
-  let mut hello_element = hello_element_result.unwrap();
-  doc.set_root_element(&mut hello_element);
+  let hello_element = hello_element_result.unwrap();
+  doc.set_root_element(&hello_element);
 
   let new_sibling = Node::new("sibling", None, &doc).unwrap();
   assert!(hello_element.add_prev_sibling(new_sibling).is_some());
@@ -151,7 +151,11 @@ fn node_children_accessors() {
   let root_children = root.get_child_nodes();
   assert_eq!(root_children.len(), 5, "file01 root has five child nodes");
   let mut element_children = root.get_child_elements();
-  assert_eq!(element_children.len(), 2, "file01 root has two child elements");
+  assert_eq!(
+    element_children.len(),
+    2,
+    "file01 root has two child elements"
+  );
   assert_eq!(element_children.pop().unwrap().get_name(), "child");
   assert_eq!(element_children.pop().unwrap().get_name(), "child");
   assert!(element_children.is_empty());
@@ -185,8 +189,11 @@ fn node_attributes_accessor() {
   assert_eq!(attr_node.get_type(), Some(NodeType::AttributeNode));
 
   // Set
-  child.set_attribute("attribute","setter_value");
-  assert_eq!(child.get_attribute("attribute"), Some("setter_value".to_string()));
+  child.set_attribute("attribute", "setter_value");
+  assert_eq!(
+    child.get_attribute("attribute"),
+    Some("setter_value".to_string())
+  );
   // Remove
   child.remove_attribute("attribute");
   assert_eq!(child.get_attribute("attribute"), None);
@@ -207,7 +214,7 @@ fn attribute_namespace_accessors() {
   let ns_result = Namespace::new("myxml", "http://www.w3.org/XML/1998/namespace", &element);
   assert!(ns_result.is_ok());
   let ns = ns_result.unwrap();
-  element.set_attribute_ns("id", "testing", ns);
+  element.set_attribute_ns("id", "testing", &ns);
 
   let id_attr = element.get_attribute_ns("id", "http://www.w3.org/XML/1998/namespace");
   assert!(id_attr.is_some());
@@ -222,7 +229,7 @@ fn attribute_namespace_accessors() {
   let fb_ns_result = Namespace::new("fb", "http://www.foobar.org", &element);
   assert!(fb_ns_result.is_ok());
   let fb_ns = fb_ns_result.unwrap();
-  element.set_attribute_ns("fb", "fb", fb_ns);
+  element.set_attribute_ns("fb", "fb", &fb_ns);
 
   let ns_prefix = element.lookup_namespace_prefix("http://www.w3.org/XML/1998/namespace");
   assert_eq!(ns_prefix, Some("xml".to_string())); // system ns has the global prefix when doing global lookup
@@ -230,7 +237,10 @@ fn attribute_namespace_accessors() {
   assert_eq!(fb_prefix, Some("fb".to_string())); // system ns has the global prefix when doing global lookup
 
   let ns_uri = element.lookup_namespace_uri("myxml");
-  assert_eq!(ns_uri, Some("http://www.w3.org/XML/1998/namespace".to_string())); // system ns has the global uri when doing global lookup
+  assert_eq!(
+    ns_uri,
+    Some("http://www.w3.org/XML/1998/namespace".to_string())
+  ); // system ns has the global uri when doing global lookup
   let fb_uri = element.lookup_namespace_uri("fb");
   assert_eq!(fb_uri, Some("http://www.foobar.org".to_string())); // system ns has the global prefix when doing global lookup
 }
@@ -294,7 +304,7 @@ fn document_can_import_node() {
 
   let elements = doc1.get_root_element().get_child_elements();
   let node = elements.first().unwrap();
-  let imported = doc2.import_node(&mut node.clone()).unwrap();
+  let imported = doc2.import_node(&node.clone()).unwrap();
   assert!(doc2.get_root_element().add_child(imported).is_ok());
 
   assert_eq!(doc2.get_root_element().get_child_elements().len(), 3);
@@ -328,9 +338,21 @@ fn xpath_with_namespaces() {
 
   let doc = doc_result.unwrap();
   let context = Context::new(&doc).unwrap();
-  assert!(context.register_namespace("h", "http://example.com/ns/hello").is_ok());
-  assert!(context.register_namespace("f", "http://example.com/ns/farewell").is_ok());
-  assert!(context.register_namespace("r", "http://example.com/ns/root").is_ok());
+  assert!(
+    context
+      .register_namespace("h", "http://example.com/ns/hello")
+      .is_ok()
+  );
+  assert!(
+    context
+      .register_namespace("f", "http://example.com/ns/farewell")
+      .is_ok()
+  );
+  assert!(
+    context
+      .register_namespace("r", "http://example.com/ns/root")
+      .is_ok()
+  );
   let result_h_td = context.evaluate("//h:td").unwrap();
   assert_eq!(result_h_td.get_number_of_nodes(), 3);
   assert_eq!(result_h_td.get_nodes_as_vec().len(), 3);
@@ -416,7 +438,8 @@ fn xpath_string_function() {
 fn well_formed_html() {
   let parser = Parser::default_html();
 
-  let trivial_well_formed = parser.is_well_formed_html("<!DOCTYPE html>\n<html><head></head><body></body></html>");
+  let trivial_well_formed =
+    parser.is_well_formed_html("<!DOCTYPE html>\n<html><head></head><body></body></html>");
   assert!(trivial_well_formed);
 
   let trivial_ill_formed = parser.is_well_formed_html("garbage");
@@ -450,7 +473,7 @@ fn can_manage_attributes() {
   let hello_element_result = Node::new("hello", None, &doc);
   assert!(hello_element_result.is_ok());
   let mut hello_element = hello_element_result.unwrap();
-  doc.set_root_element(&mut hello_element);
+  doc.set_root_element(&hello_element);
 
   let key = "examplekey";
   let value = "examplevalue";
@@ -471,9 +494,9 @@ fn can_set_get_text_node_content() {
   let hello_element_result = Node::new("hello", None, &doc);
   assert!(hello_element_result.is_ok());
   let mut hello_element = hello_element_result.unwrap();
-  doc.set_root_element(&mut hello_element);
+  doc.set_root_element(&hello_element);
 
-  assert!( hello_element.get_content().is_empty() );
+  assert!(hello_element.get_content().is_empty());
   hello_element.append_text("hello ");
   assert_eq!(hello_element.get_content(), "hello ");
   hello_element.append_text("world!");
@@ -498,7 +521,7 @@ fn can_work_with_namespaces() {
 
   // try to attach this namespace to a node
   assert!(root_node.get_namespace().is_none());
-  root_node.set_namespace(mock_ns_result.unwrap());
+  root_node.set_namespace(&mock_ns_result.unwrap());
   let active_ns_opt = root_node.get_namespace();
   assert!(active_ns_opt.is_some());
   let active_ns = active_ns_opt.unwrap();


### PR DESCRIPTION
Cosmetic changes, and a "lightweight" breaking change to the namespace argument calls
 * Added a custom rustfmt rule for tab_spaces being 2. It's an endless point of disagreement, and just fits my visual aesthetic better than 4. Might as well standardize that
 * I am now using vscode for Rust development, and am automatically running rustfmt on save, which enforced most of the styling changes in this PR
 * I also ran clippy and lifted some needless mutability and ownership requirements.

Some of these rules can likely be enhanced with better values down the line, but I find it to be a good start.

