### PR TITLE
workaround free methods, v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Change Log
-## [0.1.2 (in active dev)]
+## [0.1.3 (in active dev)]
 
- * We welcome Andreas (@triptec) to the core developer team!
+## [0.1.2] 2018-12-01
+
+* We welcome Andreas (@triptec) to the core developer team!
+
+### Added
+ 
+* Workaround `.free` method for freeing nodes, until the `Rc<RefCell<_Node>>` free-on-drop solution by Andreas is introduced in 0.2
 
 ## [0.1.1] 2017-18-12
 

--- a/src/c_signatures.rs
+++ b/src/c_signatures.rs
@@ -1,6 +1,6 @@
 //! The signatures of the c functions we'll call
 
-use libc::{c_char, c_void, c_int, c_uint, size_t};
+use libc::{c_char, c_int, c_uint, c_void, size_t};
 
 #[link(name = "xml2")]
 extern "C" {
@@ -17,7 +17,7 @@ extern "C" {
     content: *const c_char,
   ) -> *mut c_void;
   pub fn xmlNewDocText(doc: *mut c_void, content: *const c_char) -> *mut c_void;
-  // pub fn xmlFreeNode(cur: *mut c_void);
+  pub fn xmlFreeNode(cur: *mut c_void);
   pub fn xmlNewNs(node: *mut c_void, href: *const c_char, prefix: *const c_char) -> *mut c_void;
   pub fn xmlNewChild(
     parent: *mut c_void,
@@ -33,7 +33,7 @@ extern "C" {
   ) -> *mut c_void;
   // pub fn xmlNewText(parent: *mut c_void, content: *const c_char) -> *mut c_void;
   pub fn xmlNewDocPI(doc: *mut c_void, name: *const c_char, content: *const c_char) -> *mut c_void;
-  // pub fn xmlFreeNs(cur: *mut c_void);
+  pub fn xmlFreeNs(cur: *mut c_void);
   // pub fn xmlNewDocFragment(doc: *mut c_void) -> *mut c_void;
   pub fn xmlDocGetRootElement(doc: *const c_void) -> *mut c_void;
   pub fn xmlDocSetRootElement(doc: *const c_void, root: *const c_void) -> *mut c_void;

--- a/src/c_signatures.rs
+++ b/src/c_signatures.rs
@@ -8,7 +8,6 @@ extern "C" {
   pub fn xmlSaveFile(filename: *const c_char, cur: *mut c_void) -> c_int;
   pub fn xmlNewDoc(version: *const c_char) -> *mut c_void;
   pub fn xmlFreeDoc(cur: *mut c_void);
-  // pub fn xmlFree(name : *const c_char);
   // pub fn xmlNewNode(ns : *mut c_void, name: *const c_char) -> *mut c_void;
   pub fn xmlNewDocNode(
     doc: *mut c_void,
@@ -153,7 +152,6 @@ extern "C" {
   // pub fn xmlMemoryDump();
   pub fn xmlInitGlobals();
   pub fn xmlCleanupGlobals();
-  // pub fn xmlFree(some: *const c_char);
   pub fn xmlKeepBlanksDefault(flag: c_uint) -> c_uint;
   // pub fn xmlFreeParserCtxt(ctxt: *mut c_void);
   pub fn htmlFreeParserCtxt(ctxt: *mut c_void);

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -5,7 +5,7 @@ extern crate libxml;
 use std::fs::File;
 use std::io::Read;
 
-use libxml::tree::{Document, Node, Namespace, NodeType};
+use libxml::tree::{Document, Namespace, Node, NodeType};
 use libxml::xpath::Context;
 use libxml::parser::Parser;
 
@@ -58,7 +58,6 @@ fn create_pi() {
   let doc_string = doc.to_string(false);
   assert!(doc_string.len() > 1);
 }
-
 
 #[test]
 /// Duplicate an xml file
@@ -268,6 +267,11 @@ fn node_can_unbind() {
   third_child.unlink();
   assert_eq!(element.get_child_nodes().len(), 0);
 
+  // Temporary: test explicit free on unbound nodes
+  first_child.free();
+  second_child.free();
+  third_child.free();
+
   // Test reparenting via unlink
   let transfer = Node::new("transfer", None, &doc).unwrap();
   let mut transfer_child = element.add_child(transfer).unwrap();
@@ -325,7 +329,6 @@ fn xpath_result_number_correct() {
   assert_eq!(result2.get_number_of_nodes(), 0);
   assert_eq!(result2.get_nodes_as_vec().len(), 0);
 }
-
 
 #[test]
 /// Test xpath with namespaces
@@ -499,7 +502,6 @@ fn can_set_get_text_node_content() {
   assert_eq!(hello_element.get_content(), "hello ");
   hello_element.append_text("world!");
   assert_eq!(hello_element.get_content(), "hello world!");
-
 }
 
 #[test]

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -458,6 +458,7 @@ fn well_formed_html() {
 fn can_mock_node() {
   let node_mock = Node::mock();
   assert!(!node_mock.is_text_node());
+  node_mock.free();
 }
 
 #[test]
@@ -465,6 +466,7 @@ fn can_mock_node() {
 fn can_hash_mock_node() {
   let node_mock = Node::mock();
   assert!(node_mock.to_hashable() > 0);
+  node_mock.free();
 }
 
 #[test]


### PR DESCRIPTION
Hey @triptec , let me know if you can quickly review this PR.

I very quickly added a couple of free methods for nodes and namespaces to allow for some workarounds until we can adapt your work for a 0.2 release and have the crate auto-free on drop.

Need to make some quick progress, as I recall you had to some time back, and this is the most conservative approach I could take - just adding a couple of methods