### PR TITLE
Ptr bookkeeping

### DIFF
--- a/examples/tree_example.rs
+++ b/examples/tree_example.rs
@@ -29,6 +29,6 @@ fn my_recurse(node : &Node) {
 fn main() {
     let parser = Parser::default();
     let doc = parser.parse_file("tests/resources/file01.xml").unwrap();
-    let root = doc.get_root_element();
+    let root = doc.get_root_element().unwrap();
     my_recurse(&root);
 }

--- a/src/c_signatures.rs
+++ b/src/c_signatures.rs
@@ -83,8 +83,8 @@ extern "C" {
   pub fn xmlBufferContent(buf: *mut c_void) -> *const c_char;
   pub fn xmlNodeDump(
     buf: *mut c_void,
-    doc: *mut c_void,
-    node: *mut c_void,
+    doc: *const c_void,
+    node: *const c_void,
     indent: c_int,
     disable_format: c_int,
   );
@@ -165,10 +165,10 @@ extern "C" {
   pub fn xmlXPathCastToString(val: *const c_void) -> *const c_char;
   pub fn xmlXPathRegisterNs(ctxt: *mut c_void, prefix: *const c_char, href: *const c_char)
     -> c_int;
-  pub fn xmlXPathSetContextNode(node: *mut c_void, ctxt: *mut c_void) -> c_int;
-  pub fn xmlSearchNsByHref(doc: *mut c_void, node: *mut c_void, href: *const c_char)
+  pub fn xmlXPathSetContextNode(node: *const c_void, ctxt: *mut c_void) -> c_int;
+  pub fn xmlSearchNsByHref(doc: *mut c_void, node: *const c_void, href: *const c_char)
     -> *mut c_void;
-  pub fn xmlSearchNs(doc: *mut c_void, node: *mut c_void, prefix: *const c_char) -> *mut c_void;
+  pub fn xmlSearchNs(doc: *mut c_void, node: *const c_void, prefix: *const c_char) -> *mut c_void;
   // helper for xpath
   pub fn xmlXPathObjectNumberOfNodes(val: *const c_void) -> c_int;
   pub fn xmlXPathObjectGetNode(val: *const c_void, index: size_t) -> *mut c_void;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -48,6 +48,7 @@ impl Eq for Node {}
 impl Drop for Node {
   /// Free node if it isn't bound in some document
   fn drop(&mut self) {
+    //println!("Dropping node: {:?}", self.node_ptr())
     // TODO: How do we drop unbound nodes?
     // unsafe {
     //   if self.node_ptr {
@@ -57,7 +58,7 @@ impl Drop for Node {
   }
 }
 
-type DocumentRef = Rc<RefCell<_Document>>;
+pub(crate) /*Should be private, needed now for xpath*/ type DocumentRef = Rc<RefCell<_Document>>;
 
 // TODO: Do the fields need to be public in crate?
 pub(crate) struct _Document {
@@ -76,7 +77,7 @@ impl _Document {
 
 /// A libxml2 Document
 #[derive(Clone)]
-pub struct Document(DocumentRef);
+pub struct Document(pub(crate) /*Should be private i think, needed now for xpath*/ DocumentRef);
 
 /*
 #[derive(Debug)]
@@ -89,10 +90,15 @@ pub struct Document {
 impl Drop for Document {
   ///Free document when it goes out of scope
   fn drop(&mut self) {
+    //println!("Dropping document: {:?}", self.doc_ptr());
+
+    //This should be fixed
+    /*
     unsafe {
       xmlFreeDoc(self.doc_ptr());
     }
     _libxml_global_drop();
+    */
   }
 }
 
@@ -932,7 +938,7 @@ pub struct Namespace {
 
 impl Namespace {
   /// Creates a new namespace
-  pub fn new(prefix: &str, href: &str, node: &Node) -> Result<Self, ()> {
+  pub fn new(prefix: &str, href: &str, node: &mut Node) -> Result<Self, ()> {
     let c_href = CString::new(href).unwrap();
     let c_prefix = CString::new(prefix).unwrap();
     let c_prefix_ptr = if prefix.is_empty() {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -180,7 +180,7 @@ impl Document {
 
   /// Import a `Node` from another `Document`
   pub fn import_node(&mut self, node: Node) -> Result<Node, ()> {
-    if(node.0.borrow_mut().unlinked == false) {
+    if node.0.borrow_mut().unlinked == false {
       return Err(());
     }
     node.0.borrow_mut().unlinked = false;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -92,13 +92,10 @@ impl Drop for Document {
   fn drop(&mut self) {
     //println!("Dropping document: {:?}", self.doc_ptr());
 
-    //This should be fixed
-    /*
     unsafe {
       xmlFreeDoc(self.doc_ptr());
     }
     _libxml_global_drop();
-    */
   }
 }
 

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -134,9 +134,12 @@ impl Object {
       if ptr.is_null() {
         panic!("rust-libxml: xpath: found null pointer result set");
       }
-      // TODO: This is the reason that there isn't a drop on Document, how to do this without creating a Document here that get dropped???
-      let doc = Document(self.document.clone());
-      vec.push(doc.register_node(ptr)); //node_is_inserted : true
+
+      /* TODO: break next two lines into a method on _Docuemnt */
+      let node = Node::wrap(ptr, self.document.clone());
+      self.document.borrow_mut().insert_node(ptr, node.clone());
+
+      vec.push(node); //node_is_inserted : true
     }
     vec
   }

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -36,7 +36,7 @@ pub struct Object {
 impl<'a> Context<'a> {
   ///create the xpath context for a document
   pub fn new(doc: &Document) -> Result<Context, ()> {
-    let ctxtptr: *mut c_void = unsafe { xmlXPathNewContext(doc.doc_ptr) };
+    let ctxtptr: *mut c_void = unsafe { xmlXPathNewContext(doc.doc_ptr()) };
     if ctxtptr.is_null() {
       Err(())
     } else {
@@ -133,7 +133,8 @@ impl Object {
       if ptr.is_null() {
         panic!("rust-libxml: xpath: found null pointer result set");
       }
-      vec.push(Node { node_ptr: ptr }); //node_is_inserted : true
+      // TODO: Fix another day =)
+      //vec.push(Node { node_ptr: ptr }); //node_is_inserted : true
     }
     vec
   }

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -2,7 +2,7 @@
 
 use c_signatures::*;
 use libc::{c_void, size_t};
-use tree::{Document, Node};
+use tree::{Document, DocumentRef, Node};
 use std::str;
 use std::ffi::{CStr, CString};
 
@@ -30,6 +30,7 @@ impl<'a> Drop for Context<'a> {
 pub struct Object {
   ///libxml's `ObjectPtr`
   pub ptr: *mut c_void,
+  document: DocumentRef,
 }
 
 
@@ -64,7 +65,7 @@ impl<'a> Context<'a> {
     if result.is_null() {
       Err(())
     } else {
-      Ok(Object { ptr: result })
+      Ok(Object { ptr: result, document: self.document.0.clone()})
     }
   }
 
@@ -133,8 +134,9 @@ impl Object {
       if ptr.is_null() {
         panic!("rust-libxml: xpath: found null pointer result set");
       }
-      // TODO: Fix another day =)
-      //vec.push(Node { node_ptr: ptr }); //node_is_inserted : true
+      // TODO: This is the reason that there isn't a drop on Document, how to do this without creating a Document here that get dropped???
+      let doc = Document(self.document.clone());
+      vec.push(doc.register_node(ptr)); //node_is_inserted : true
     }
     vec
   }

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -71,7 +71,7 @@ impl<'a> Context<'a> {
   /// localize xpath context to a specific Node
   pub fn set_context_node(&mut self, node: &Node) -> Result<(), ()> {
     unsafe {
-      let result = xmlXPathSetContextNode(node.node_ptr, self.context_ptr);
+      let result = xmlXPathSetContextNode(node.node_ptr(), self.context_ptr);
       if result != 0 {
         return Err(());
       }

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -8,7 +8,7 @@ use std::io::Read;
 use libxml::tree::{Document, Namespace, Node, NodeType};
 use libxml::xpath::Context;
 use libxml::parser::Parser;
-
+use std::borrow::BorrowMut;
 #[test]
 /// Build a hello world XML doc
 fn hello_builder() {
@@ -134,7 +134,7 @@ fn node_sibling_accessors() {
   doc.set_root_element(&hello_element);
 
   let new_sibling = Node::new("sibling", None, &doc).unwrap();
-  assert!(hello_element.add_prev_sibling(&new_sibling).is_ok());
+  assert!(hello_element.add_prev_sibling(new_sibling).is_ok());
 }
 
 #[test]
@@ -306,9 +306,10 @@ fn document_can_import_node() {
 
   assert_eq!(doc2.get_root_element().unwrap().get_child_elements().len(), 2);
 
-  let elements = doc1.get_root_element().unwrap().get_child_elements();
-  let node = elements.first().unwrap();
-  let imported = doc2.import_node(&node).unwrap();
+  let mut elements = doc1.get_root_element().unwrap().get_child_elements();
+  let mut node = elements.pop().unwrap();
+  node.unlink();
+  let imported = doc2.import_node(node).unwrap();
   assert!(doc2.get_root_element().unwrap().add_child(imported).is_ok());
 
   assert_eq!(doc2.get_root_element().unwrap().get_child_elements().len(), 3);

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -8,7 +8,7 @@ use std::io::Read;
 use libxml::tree::{Document, Namespace, Node, NodeType};
 use libxml::xpath::Context;
 use libxml::parser::Parser;
-use std::borrow::BorrowMut;
+
 #[test]
 /// Build a hello world XML doc
 fn hello_builder() {

--- a/tests/ownership_flaws.rs
+++ b/tests/ownership_flaws.rs
@@ -11,7 +11,7 @@ fn ownership_guards() {
   let doc_result = parser.parse_file("tests/resources/file01.xml");
   assert!(doc_result.is_ok());
   let doc = doc_result.unwrap();
-  let root = doc.get_root_element();
+  let root = doc.get_root_element().unwrap();
 
   let mut first_a = root.get_first_element_child().unwrap();
   let first_b = root.get_first_element_child().unwrap();


### PR DESCRIPTION
I've added ptr bookkeeping to nodes, we should do some bookkeeping of namespaces as well but lets start here.

I suggest we first check if this fills the need of not leaking memory.

After that I suggest we first fix the api, I might have made some bad choices and there are questions, should add_* and import_node consume the node passed to them, should unlink() consume self etc.

When we feel the api makes sense lets document the methods etc.

I'm not suggesting we merge this anytime soon and I need comments on it to take this forward.