### PR TITLE
Enhance tree modularity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This release adds fundamental breaking changes to the API. The API continues to 
 
 ### Added
  * `dup` and `dup_from` methods for deeply duplicating a libxml2 document
+ * `is_unlinked` for quick check if a `Node` has been unlinked from a parent
 
 ### Changed
  * safe API for `Node`s and `Document`s, with automatic pointer bookkeeping and memory deallocation, by @triptec

--- a/examples/tree_example.rs
+++ b/examples/tree_example.rs
@@ -1,34 +1,33 @@
 extern crate libxml;
 
+use libxml::parser::Parser;
 use libxml::tree::*;
-use libxml::parser::{Parser};
 
-
-fn my_recurse(node : &Node) {
-    match node.get_type().unwrap() {
-       NodeType::ElementNode => {
-           println!("Entering {}", node.get_name());
-       }
-       NodeType::TextNode => {
-           println!("Text: {}", node.get_content());
-       }
-        _ => { }
+fn my_recurse(node: &Node) {
+  match node.get_type().unwrap() {
+    NodeType::ElementNode => {
+      println!("Entering {}", node.get_name());
     }
-
-    let mut c : Option<Node> = node.get_first_child();
-    while let Some(child) = c {
-      my_recurse(&child);
-      c = child.get_next_sibling();
+    NodeType::TextNode => {
+      println!("Text: {}", node.get_content());
     }
+    _ => {}
+  }
 
-    if node.get_type().unwrap() == NodeType::ElementNode {
-        println!("Leaving {}", node.get_name());
-    }
+  let mut c: Option<Node> = node.get_first_child();
+  while let Some(child) = c {
+    my_recurse(&child);
+    c = child.get_next_sibling();
+  }
+
+  if node.get_type().unwrap() == NodeType::ElementNode {
+    println!("Leaving {}", node.get_name());
+  }
 }
 
 fn main() {
-    let parser = Parser::default();
-    let doc = parser.parse_file("tests/resources/file01.xml").unwrap();
-    let root = doc.get_root_element().unwrap();
-    my_recurse(&root);
+  let parser = Parser::default();
+  let doc = parser.parse_file("tests/resources/file01.xml").unwrap();
+  let root = doc.get_root_element().unwrap();
+  my_recurse(&root);
 }

--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -1,0 +1,228 @@
+//! Document feature set
+//!
+
+use c_signatures::*;
+use libc;
+use libc::{c_int, c_void};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ffi::{CStr, CString};
+use std::ptr;
+use std::rc::Rc;
+use std::str;
+
+use tree::node::Node;
+
+pub(crate) type DocumentRef = Rc<RefCell<_Document>>;
+
+// TODO: Do the fields need to be public in crate?
+#[derive(Debug)]
+pub(crate) struct _Document {
+  /// libxml's `DocumentPtr`
+  pub(crate) doc_ptr: *mut c_void,
+  pub(crate) nodes: HashMap<*mut c_void, Node>,
+}
+
+impl _Document {
+  /// Internal bookkeeping function, so far only used by `Node::wrap`
+  pub(crate) fn insert_node(&mut self, node_ptr: *mut c_void, node: Node) {
+    self.nodes.insert(node_ptr, node);
+  }
+}
+
+/// A libxml2 Document
+#[derive(Clone)]
+pub struct Document(pub(crate) DocumentRef);
+
+impl Drop for Document {
+  ///Free document when it goes out of scope
+  fn drop(&mut self) {
+    unsafe {
+      xmlFreeDoc(self.doc_ptr());
+    }
+  }
+}
+
+impl Document {
+  /// Creates a new empty libxml2 document
+  pub fn new() -> Result<Self, ()> {
+    unsafe {
+      let c_version = CString::new("1.0").unwrap();
+      let doc_ptr = xmlNewDoc(c_version.as_ptr());
+      if doc_ptr.is_null() {
+        Err(())
+      } else {
+        let doc = _Document {
+          doc_ptr,
+          nodes: HashMap::new(),
+        };
+        Ok(Document(Rc::new(RefCell::new(doc))))
+      }
+    }
+  }
+
+  pub(crate) fn doc_ptr(&self) -> *mut c_void {
+    self.0.borrow().doc_ptr
+  }
+
+  /// Creates a new `Document` from an existing libxml2 pointer
+  pub fn new_ptr(doc_ptr: *mut c_void) -> Self {
+    let doc = _Document {
+      doc_ptr,
+      nodes: HashMap::new(),
+    };
+    Document(Rc::new(RefCell::new(doc)))
+  }
+  /// Write document to `filename`
+  pub fn save_file(&self, filename: &str) -> Result<c_int, ()> {
+    let c_filename = CString::new(filename).unwrap();
+    unsafe {
+      let retval = xmlSaveFile(c_filename.as_ptr(), self.doc_ptr());
+      if retval < 0 {
+        return Err(());
+      }
+      Ok(retval)
+    }
+  }
+
+  pub(crate) fn register_node(&self, node_ptr: *mut c_void) -> Node {
+    Node::wrap(node_ptr, self.0.clone())
+  }
+
+  /// Get the root element of the document
+  pub fn get_root_element(&self) -> Option<Node> {
+    unsafe {
+      let node_ptr = xmlDocGetRootElement(self.doc_ptr());
+      if node_ptr.is_null() {
+        None
+      } else {
+        Some(self.register_node(node_ptr))
+      }
+    }
+  }
+
+  /// Sets the root element of the document
+  pub fn set_root_element(&mut self, root: &Node) {
+    unsafe {
+      xmlDocSetRootElement(self.doc_ptr(), root.node_ptr());
+      // root.node_is_inserted = true;
+    }
+  }
+
+  fn ptr_as_result(&mut self, node_ptr: *mut c_void) -> Result<Node, ()> {
+    if node_ptr.is_null() {
+      Err(())
+    } else {
+      let node = self.register_node(node_ptr);
+      Ok(node)
+    }
+  }
+
+  /// Import a `Node` from another `Document`
+  pub fn import_node(&mut self, node: &mut Node) -> Result<Node, ()> {
+    if !node.is_unlinked() {
+      return Err(());
+    }
+
+    let node_ptr = unsafe { xmlDocCopyNode(node.node_ptr(), self.doc_ptr(), 1) };
+    self.ptr_as_result(node_ptr)
+  }
+
+  /// Serializes the `Document`
+  pub fn to_string(&self, format: bool) -> String {
+    unsafe {
+      // allocate a buffer to dump into
+      let mut receiver = ptr::null_mut();
+      let size: c_int = 0;
+      let c_utf8 = CString::new("UTF-8").unwrap();
+
+      if !format {
+        xmlDocDumpMemoryEnc(self.doc_ptr(), &mut receiver, &size, c_utf8.as_ptr(), 1);
+      } else {
+        let current_indent = getIndentTreeOutput();
+        setIndentTreeOutput(1);
+        xmlDocDumpFormatMemoryEnc(self.doc_ptr(), &mut receiver, &size, c_utf8.as_ptr(), 1);
+        setIndentTreeOutput(current_indent);
+      }
+
+      let c_string = CStr::from_ptr(receiver);
+      let node_string = c_string.to_string_lossy().into_owned();
+      libc::free(receiver as *mut c_void);
+
+      node_string
+    }
+  }
+
+  /// Serializes a `Node` owned by this `Document
+  pub fn node_to_string(&self, node: &Node) -> String {
+    unsafe {
+      // allocate a buffer to dump into
+      let buf = xmlBufferCreate();
+
+      // dump the node
+      xmlNodeDump(
+        buf,
+        self.doc_ptr(),
+        node.node_ptr(),
+        1, // level of indentation
+        0, /* disable formatting */
+      );
+      let result_ptr = xmlBufferContent(buf);
+      let c_string = CStr::from_ptr(result_ptr);
+      let node_string = c_string.to_string_lossy().into_owned();
+      xmlBufferFree(buf);
+
+      node_string
+    }
+  }
+
+  /// Creates a node for an XML processing instruction
+  pub fn create_processing_instruction(&mut self, name: &str, content: &str) -> Result<Node, ()> {
+    unsafe {
+      let c_name = CString::new(name).unwrap();
+      let c_content = CString::new(content).unwrap();
+
+      let node_ptr = xmlNewDocPI(self.doc_ptr(), c_name.as_ptr(), c_content.as_ptr());
+      if node_ptr.is_null() {
+        Err(())
+      } else {
+        Ok(self.register_node(node_ptr))
+      }
+    }
+  }
+
+  // TODO: Discuss use case, this could probably cause problems
+  /// Cast the document as a libxml Node
+  pub fn as_node(&self) -> Node {
+    // TODO: Memory management? Could be a major pain...
+    self.register_node(self.doc_ptr())
+  }
+
+  /// Duplicates the libxml2 Document into a new instance
+  pub fn dup(&self) -> Result<Self, ()> {
+    let doc_ptr = unsafe { xmlCopyDoc(self.doc_ptr(), 1) };
+    if doc_ptr.is_null() {
+      Err(())
+    } else {
+      let doc = _Document {
+        doc_ptr,
+        nodes: HashMap::new(),
+      };
+      Ok(Document(Rc::new(RefCell::new(doc))))
+    }
+  }
+
+  /// Duplicates a source libxml2 Document into the empty Document self
+  pub fn dup_from(&mut self, source: &Self) -> Result<(), ()> {
+    if !self.doc_ptr().is_null() {
+      return Err(());
+    }
+
+    let doc_ptr = unsafe { xmlCopyDoc(source.doc_ptr(), 1) };
+    if doc_ptr.is_null() {
+      return Err(());
+    }
+    self.0.borrow_mut().doc_ptr = doc_ptr;
+    Ok(())
+  }
+}

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1,10 +1,10 @@
 //! The tree functionality
 //!
 
-pub mod document;
-pub mod namespace;
-pub mod node;
-pub mod nodetype;
+mod document;
+mod namespace;
+mod node;
+mod nodetype;
 
 pub use tree::document::Document;
 pub(crate) use tree::document::DocumentRef;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -4,9 +4,10 @@
 pub mod document;
 pub mod namespace;
 pub mod node;
+pub mod nodetype;
 
 pub use tree::document::Document;
-pub use tree::namespace::Namespace;
-pub use tree::node::{Node, NodeType};
-
 pub(crate) use tree::document::DocumentRef;
+pub use tree::namespace::Namespace;
+pub use tree::node::Node;
+pub use tree::nodetype::NodeType;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1,0 +1,12 @@
+//! The tree functionality
+//!
+
+pub mod document;
+pub mod namespace;
+pub mod node;
+
+pub use tree::document::Document;
+pub use tree::namespace::Namespace;
+pub use tree::node::{Node, NodeType};
+
+pub(crate) use tree::document::DocumentRef;

--- a/src/tree/namespace.rs
+++ b/src/tree/namespace.rs
@@ -1,0 +1,72 @@
+//! Namespace feature set
+//!
+
+use c_signatures::*;
+use libc::c_void;
+use std::ffi::{CStr, CString};
+use std::ptr;
+use std::str;
+
+use tree::node::Node;
+
+///An xml namespace
+#[derive(Clone)]
+pub struct Namespace {
+  ///libxml's xmlNsPtr
+  pub(crate) ns_ptr: *mut c_void,
+}
+
+impl Namespace {
+  /// Creates a new namespace
+  pub fn new(prefix: &str, href: &str, node: &mut Node) -> Result<Self, ()> {
+    let c_href = CString::new(href).unwrap();
+    let c_prefix = CString::new(prefix).unwrap();
+    let c_prefix_ptr = if prefix.is_empty() {
+      ptr::null()
+    } else {
+      c_prefix.as_ptr()
+    };
+
+    unsafe {
+      let ns = xmlNewNs(node.node_ptr_mut(), c_href.as_ptr(), c_prefix_ptr);
+      if ns.is_null() {
+        Err(())
+      } else {
+        Ok(Namespace { ns_ptr: ns })
+      }
+    }
+  }
+  pub(crate) fn ns_ptr(&self) -> *mut c_void {
+    self.ns_ptr
+  }
+  /// The namespace prefix
+  pub fn get_prefix(&self) -> String {
+    unsafe {
+      let prefix_ptr = xmlNsPrefix(self.ns_ptr());
+      if prefix_ptr.is_null() {
+        String::new()
+      } else {
+        let c_prefix = CStr::from_ptr(prefix_ptr);
+        c_prefix.to_string_lossy().into_owned()
+      }
+    }
+  }
+
+  /// The namespace href
+  pub fn get_href(&self) -> String {
+    unsafe {
+      let href_ptr = xmlNsHref(self.ns_ptr());
+      if href_ptr.is_null() {
+        String::new()
+      } else {
+        let c_href = CStr::from_ptr(href_ptr);
+        c_href.to_string_lossy().into_owned()
+      }
+    }
+  }
+
+  /// Explicit free method, until (if?) we implement automatic+safe free-on-drop
+  pub fn free(&mut self) {
+    unsafe { xmlFreeNs(self.ns_ptr()) }
+  }
+}

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1,276 +1,20 @@
-//! The tree functionality
-use c_signatures::*;
+//! Node, and related, feature set
+//!
 
+use c_signatures::*;
 use libc;
 use libc::{c_int, c_void};
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::ffi::{CStr, CString};
 use std::hash::{Hash, Hasher};
 use std::mem;
 use std::ptr;
+use std::rc::Rc;
 use std::str;
 
-use std::cell::RefCell;
-use std::rc::Rc;
-
-type NodeRef = Rc<RefCell<_Node>>;
-
-#[derive(Debug)]
-struct _Node {
-  /// libxml's xmlNodePtr
-  node_ptr: *mut c_void,
-  /// Reference to parent `Document`
-  document: DocumentRef,
-  unlinked: bool,
-}
-
-/// An xml node
-#[derive(Clone, Debug)]
-pub struct Node(NodeRef);
-
-impl Hash for Node {
-  /// Generates a hash value from the `node_ptr` value.
-  fn hash<H: Hasher>(&self, state: &mut H) {
-    self.node_ptr().hash(state);
-  }
-}
-
-impl PartialEq for Node {
-  /// Two nodes are considered equal, if they point to the same xmlNode.
-  fn eq(&self, other: &Node) -> bool {
-    self.node_ptr() == other.node_ptr()
-  }
-}
-
-impl Eq for Node {}
-
-impl Drop for Node {
-  /// Free node if it isn't bound in some document
-  fn drop(&mut self) {
-    if self.0.borrow().unlinked {
-      let node_ptr = self.node_ptr_mut();
-      if !node_ptr.is_null() {
-        unsafe {
-          xmlFreeNode(node_ptr);
-        }
-      }
-    }
-  }
-}
-
-pub(crate) type DocumentRef = Rc<RefCell<_Document>>;
-
-// TODO: Do the fields need to be public in crate?
-#[derive(Debug)]
-pub(crate) struct _Document {
-  /// libxml's `DocumentPtr`
-  pub(crate) doc_ptr: *mut c_void,
-  pub(crate) nodes: HashMap<*mut c_void, Node>,
-}
-
-impl _Document {
-  /// Internal bookkeeping function, so far only used by `Node::wrap`
-  pub(crate) fn insert_node(&mut self, node_ptr: *mut c_void, node: Node) {
-    self.nodes.insert(node_ptr, node);
-  }
-}
-
-/// A libxml2 Document
-#[derive(Clone)]
-pub struct Document(pub(crate) DocumentRef);
-
-impl Drop for Document {
-  ///Free document when it goes out of scope
-  fn drop(&mut self) {
-    unsafe {
-      xmlFreeDoc(self.doc_ptr());
-    }
-  }
-}
-
-impl Document {
-  /// Creates a new empty libxml2 document
-  pub fn new() -> Result<Self, ()> {
-    unsafe {
-      let c_version = CString::new("1.0").unwrap();
-      let doc_ptr = xmlNewDoc(c_version.as_ptr());
-      if doc_ptr.is_null() {
-        Err(())
-      } else {
-        let doc = _Document {
-          doc_ptr,
-          nodes: HashMap::new(),
-        };
-        Ok(Document(Rc::new(RefCell::new(doc))))
-      }
-    }
-  }
-
-  pub(crate) fn doc_ptr(&self) -> *mut c_void {
-    self.0.borrow().doc_ptr
-  }
-
-  /// Creates a new `Document` from an existing libxml2 pointer
-  pub fn new_ptr(doc_ptr: *mut c_void) -> Self {
-    let doc = _Document {
-      doc_ptr,
-      nodes: HashMap::new(),
-    };
-    Document(Rc::new(RefCell::new(doc)))
-  }
-  /// Write document to `filename`
-  pub fn save_file(&self, filename: &str) -> Result<c_int, ()> {
-    let c_filename = CString::new(filename).unwrap();
-    unsafe {
-      let retval = xmlSaveFile(c_filename.as_ptr(), self.doc_ptr());
-      if retval < 0 {
-        return Err(());
-      }
-      Ok(retval)
-    }
-  }
-
-  pub(crate) fn register_node(&self, node_ptr: *mut c_void) -> Node {
-    Node::wrap(node_ptr, self.0.clone())
-  }
-
-  /// Get the root element of the document
-  pub fn get_root_element(&self) -> Option<Node> {
-    unsafe {
-      let node_ptr = xmlDocGetRootElement(self.doc_ptr());
-      if node_ptr.is_null() {
-        None
-      } else {
-        Some(self.register_node(node_ptr))
-      }
-    }
-  }
-
-  /// Sets the root element of the document
-  pub fn set_root_element(&mut self, root: &Node) {
-    unsafe {
-      xmlDocSetRootElement(self.doc_ptr(), root.node_ptr());
-      // root.node_is_inserted = true;
-    }
-  }
-
-  fn ptr_as_result(&mut self, node_ptr: *mut c_void) -> Result<Node, ()> {
-    if node_ptr.is_null() {
-      Err(())
-    } else {
-      let node = self.register_node(node_ptr);
-      Ok(node)
-    }
-  }
-
-  /// Import a `Node` from another `Document`
-  pub fn import_node(&mut self, node: &mut Node) -> Result<Node, ()> {
-    if !node.0.borrow_mut().unlinked {
-      return Err(());
-    }
-
-    let node_ptr = unsafe { xmlDocCopyNode(node.node_ptr(), self.doc_ptr(), 1) };
-    self.ptr_as_result(node_ptr)
-  }
-
-  /// Serializes the `Document`
-  pub fn to_string(&self, format: bool) -> String {
-    unsafe {
-      // allocate a buffer to dump into
-      let mut receiver = ptr::null_mut();
-      let size: c_int = 0;
-      let c_utf8 = CString::new("UTF-8").unwrap();
-
-      if !format {
-        xmlDocDumpMemoryEnc(self.doc_ptr(), &mut receiver, &size, c_utf8.as_ptr(), 1);
-      } else {
-        let current_indent = getIndentTreeOutput();
-        setIndentTreeOutput(1);
-        xmlDocDumpFormatMemoryEnc(self.doc_ptr(), &mut receiver, &size, c_utf8.as_ptr(), 1);
-        setIndentTreeOutput(current_indent);
-      }
-
-      let c_string = CStr::from_ptr(receiver);
-      let node_string = c_string.to_string_lossy().into_owned();
-      libc::free(receiver as *mut c_void);
-
-      node_string
-    }
-  }
-
-  /// Serializes a `Node` owned by this `Document
-  pub fn node_to_string(&self, node: &Node) -> String {
-    unsafe {
-      // allocate a buffer to dump into
-      let buf = xmlBufferCreate();
-
-      // dump the node
-      xmlNodeDump(
-        buf,
-        self.doc_ptr(),
-        node.node_ptr(),
-        1, // level of indentation
-        0, /* disable formatting */
-      );
-      let result_ptr = xmlBufferContent(buf);
-      let c_string = CStr::from_ptr(result_ptr);
-      let node_string = c_string.to_string_lossy().into_owned();
-      xmlBufferFree(buf);
-
-      node_string
-    }
-  }
-
-  /// Creates a node for an XML processing instruction
-  pub fn create_processing_instruction(&mut self, name: &str, content: &str) -> Result<Node, ()> {
-    unsafe {
-      let c_name = CString::new(name).unwrap();
-      let c_content = CString::new(content).unwrap();
-
-      let node_ptr = xmlNewDocPI(self.doc_ptr(), c_name.as_ptr(), c_content.as_ptr());
-      if node_ptr.is_null() {
-        Err(())
-      } else {
-        Ok(self.register_node(node_ptr))
-      }
-    }
-  }
-
-  // TODO: Discuss use case, this could probably cause problems
-  /// Cast the document as a libxml Node
-  pub fn as_node(&self) -> Node {
-    // TODO: Memory management? Could be a major pain...
-    self.register_node(self.doc_ptr())
-  }
-
-  /// Duplicates the libxml2 Document into a new instance
-  pub fn dup(&self) -> Result<Self, ()> {
-    let doc_ptr = unsafe { xmlCopyDoc(self.doc_ptr(), 1) };
-    if doc_ptr.is_null() {
-      Err(())
-    } else {
-      let doc = _Document {
-        doc_ptr,
-        nodes: HashMap::new(),
-      };
-      Ok(Document(Rc::new(RefCell::new(doc))))
-    }
-  }
-
-  /// Duplicates a source libxml2 Document into the empty Document self
-  pub fn dup_from(&mut self, source: &Self) -> Result<(), ()> {
-    if !self.doc_ptr().is_null() {
-      return Err(());
-    }
-
-    let doc_ptr = unsafe { xmlCopyDoc(source.doc_ptr(), 1) };
-    if doc_ptr.is_null() {
-      return Err(());
-    }
-    self.0.borrow_mut().doc_ptr = doc_ptr;
-    Ok(())
-  }
-}
+use tree::document::{Document, DocumentRef};
+use tree::namespace::Namespace;
 
 /// Types of xml nodes
 #[derive(Debug, PartialEq)]
@@ -326,6 +70,51 @@ impl NodeType {
       20 => Some(NodeType::XIncludeEnd),
       21 => Some(NodeType::DOCBDocumentNode),
       _ => None,
+    }
+  }
+}
+
+type NodeRef = Rc<RefCell<_Node>>;
+
+#[derive(Debug)]
+struct _Node {
+  /// libxml's xmlNodePtr
+  node_ptr: *mut c_void,
+  /// Reference to parent `Document`
+  document: DocumentRef,
+  unlinked: bool,
+}
+
+/// An xml node
+#[derive(Clone, Debug)]
+pub struct Node(NodeRef);
+
+impl Hash for Node {
+  /// Generates a hash value from the `node_ptr` value.
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    self.node_ptr().hash(state);
+  }
+}
+
+impl PartialEq for Node {
+  /// Two nodes are considered equal, if they point to the same xmlNode.
+  fn eq(&self, other: &Node) -> bool {
+    self.node_ptr() == other.node_ptr()
+  }
+}
+
+impl Eq for Node {}
+
+impl Drop for Node {
+  /// Free node if it isn't bound in some document
+  fn drop(&mut self) {
+    if self.0.borrow().unlinked {
+      let node_ptr = self.node_ptr_mut();
+      if !node_ptr.is_null() {
+        unsafe {
+          xmlFreeNode(node_ptr);
+        }
+      }
     }
   }
 }
@@ -897,6 +686,11 @@ impl Node {
     self.unlink_node()
   }
 
+  /// Checks if node is marked as unlinked
+  pub fn is_unlinked(&self) -> bool {
+    self.0.borrow().unlinked
+  }
+
   fn ptr_as_option(&self, node_ptr: *mut c_void) -> Option<Node> {
     if node_ptr.is_null() {
       None
@@ -914,67 +708,5 @@ impl Node {
   /// internal helper to ensure the node is marked as unlinked/removed from the main document tree
   fn set_unlinked(&mut self) {
     self.0.borrow_mut().unlinked = true;
-  }
-}
-
-///An xml namespace
-#[derive(Clone)]
-pub struct Namespace {
-  ///libxml's xmlNsPtr
-  pub(crate) ns_ptr: *mut c_void,
-}
-
-impl Namespace {
-  /// Creates a new namespace
-  pub fn new(prefix: &str, href: &str, node: &mut Node) -> Result<Self, ()> {
-    let c_href = CString::new(href).unwrap();
-    let c_prefix = CString::new(prefix).unwrap();
-    let c_prefix_ptr = if prefix.is_empty() {
-      ptr::null()
-    } else {
-      c_prefix.as_ptr()
-    };
-
-    unsafe {
-      let ns = xmlNewNs(node.node_ptr_mut(), c_href.as_ptr(), c_prefix_ptr);
-      if ns.is_null() {
-        Err(())
-      } else {
-        Ok(Namespace { ns_ptr: ns })
-      }
-    }
-  }
-  fn ns_ptr(&self) -> *mut c_void {
-    self.ns_ptr
-  }
-  /// The namespace prefix
-  pub fn get_prefix(&self) -> String {
-    unsafe {
-      let prefix_ptr = xmlNsPrefix(self.ns_ptr());
-      if prefix_ptr.is_null() {
-        String::new()
-      } else {
-        let c_prefix = CStr::from_ptr(prefix_ptr);
-        c_prefix.to_string_lossy().into_owned()
-      }
-    }
-  }
-
-  /// The namespace href
-  pub fn get_href(&self) -> String {
-    unsafe {
-      let href_ptr = xmlNsHref(self.ns_ptr());
-      if href_ptr.is_null() {
-        String::new()
-      } else {
-        let c_href = CStr::from_ptr(href_ptr);
-        c_href.to_string_lossy().into_owned()
-      }
-    }
-  }
-
-  /// Explicit free method, until (if?) we implement automatic+safe free-on-drop
-  pub fn free(&mut self) {
-    unsafe { xmlFreeNs(self.ns_ptr()) }
   }
 }

--- a/src/tree/nodetype.rs
+++ b/src/tree/nodetype.rs
@@ -1,0 +1,61 @@
+//! Types of libxml2 Nodes
+//!
+use libc::c_int;
+
+/// Types of xml nodes
+#[derive(Debug, PartialEq)]
+#[allow(missing_docs)]
+pub enum NodeType {
+  ElementNode,
+  AttributeNode,
+  TextNode,
+  CDataSectionNode,
+  EntityRefNode,
+  EntityNode,
+  PiNode,
+  CommentNode,
+  DocumentNode,
+  DocumentTypeNode,
+  DocumentFragNode,
+  NotationNode,
+  HtmlDocumentNode,
+  DTDNode,
+  ElementDecl,
+  AttributeDecl,
+  EntityDecl,
+  NamespaceDecl,
+  XIncludeStart,
+  XIncludeEnd,
+  DOCBDocumentNode,
+}
+
+impl NodeType {
+  /// converts an integer from libxml's `enum NodeType`
+  /// to an instance of our `NodeType`
+  pub fn from_c_int(i: c_int) -> Option<NodeType> {
+    match i {
+      1 => Some(NodeType::ElementNode),
+      2 => Some(NodeType::AttributeNode),
+      3 => Some(NodeType::TextNode),
+      4 => Some(NodeType::CDataSectionNode),
+      5 => Some(NodeType::EntityRefNode),
+      6 => Some(NodeType::EntityNode),
+      7 => Some(NodeType::PiNode),
+      8 => Some(NodeType::CommentNode),
+      9 => Some(NodeType::DocumentNode),
+      10 => Some(NodeType::DocumentTypeNode),
+      11 => Some(NodeType::DocumentFragNode),
+      12 => Some(NodeType::NotationNode),
+      13 => Some(NodeType::HtmlDocumentNode),
+      14 => Some(NodeType::DTDNode),
+      15 => Some(NodeType::ElementDecl),
+      16 => Some(NodeType::AttributeDecl),
+      17 => Some(NodeType::EntityDecl),
+      18 => Some(NodeType::NamespaceDecl),
+      19 => Some(NodeType::XIncludeStart),
+      20 => Some(NodeType::XIncludeEnd),
+      21 => Some(NodeType::DOCBDocumentNode),
+      _ => None,
+    }
+  }
+}


### PR DESCRIPTION
For @triptec to quickly review - I went ahead and split out the four individual sub-modules of tree into their own Rust files, and organized them via `tree/mod.rs`.

The node implementation is still too large, but can last a bit longer as-is now. Feel free to take a quick look.

Aside: Additionally, I refactored 3 repositories that I have which work with rust-libxml to the latest master, and the edits were quite manageable - was done in 30 minutes with all 3. So the new API feels good-to-go in that regard. Still to profile for memory leaks there, but that will be my next PR.