### PR TITLE
Allow for higher Rc count mutability treshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 ## [0.2.1 (in active dev)]
+ * Added `Node::set_node_rc_guard` which allows customizing the reference-count mutability threshold for Nodes.
 
 ## [0.2.0] 2018-19-07
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -9,5 +9,6 @@ mod nodetype;
 pub use tree::document::Document;
 pub(crate) use tree::document::DocumentRef;
 pub use tree::namespace::Namespace;
-pub use tree::node::Node;
+pub use tree::node::set_node_rc_guard;
+pub use tree::node::{Node, NODE_RC_MAX_GUARD};
 pub use tree::nodetype::NodeType;

--- a/tests/mutability_guards.rs
+++ b/tests/mutability_guards.rs
@@ -3,6 +3,7 @@
 extern crate libxml;
 
 use libxml::parser::Parser;
+use libxml::tree::set_node_rc_guard;
 
 #[test]
 fn ownership_guards() {
@@ -37,5 +38,22 @@ fn ownership_guards() {
   assert_eq!(
     first_b.get_attribute("attribute"),
     Some(String::from("value"))
+  );
+
+  // Try again with guard boosted, which allows the change
+  set_node_rc_guard(3);
+
+  // Setting an attribute will fail and return an error, as there are too many Rc references
+  // to the same node (Rc strong count of 3)
+  // see `Node::node_ptr_mut` for details
+  assert!(first_a.set_attribute("attribute", "newa").is_ok());
+
+  assert_eq!(
+    first_a.get_attribute("attribute"),
+    Some(String::from("newa"))
+  );
+  assert_eq!(
+    first_b.get_attribute("attribute"),
+    Some(String::from("newa"))
   );
 }


### PR DESCRIPTION
As it so happens, one of my private projects using the grate hit an error with an Rc strong count of 5 (five)! Which was shocking.

One of the techniques I use there is legitimate - I am similarly bookkeeping nodes as a "current insertion point" during a document construction traversal that keeps absorbing content and moving up-and-down the tree as appropriate.

So I would expect an Rc strong count of at least 3 to be acceptable. And possibly even 5 with the specific function in question. The code is pretty directly ported from Perl's use of Nodes in XML::LibXML, and naturally Perl allows the mutability conflicts without any concern. I could try to completely rework that bit of code, and that may be a good idea for new projects, but for now I would prefer to have the simple option of raising the threshold.

Time for a quick 0.2.1 ? 