### PR TITLE
Allow for direct node.findnodes calls without explicit context creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Change Log
 
+## [0.2.4] (in active development)
 
-## [0.2.3] (in active development)
+## [0.2.3] 2018-19-2018
 
+### Added
+ * `Node::findnodes` method for direct XPath search, without first explicitly instantiating a `Context`. Reusing a `Context` remains more efficient.
 
 ## [0.2.2] 2018-23-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libxml"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Andreas Franzén <andreas@devil.se>", "Deyan Ginev <deyan.ginev@gmail.com>","Jan Frederik Schaefer <j.schaefer@jacobs-university.de>"]
 description = "A Rust wrapper for libxml2 - the XML C parser and toolkit developed for the Gnome project"
 repository = "https://github.com/KWARC/rust-libxml"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -82,7 +82,8 @@ impl Parser {
   pub fn parse_file(&self, filename: &str) -> Result<Document, XmlParseError> {
     let c_filename = CString::new(filename).unwrap();
     let c_utf8 = CString::new("utf-8").unwrap();
-    let options: i32 = XmlParserOption::Recover as i32 + XmlParserOption::Noerror as i32
+    let options: i32 = XmlParserOption::Recover as i32
+      + XmlParserOption::Noerror as i32
       + XmlParserOption::Nowarning as i32;
     match self.format {
       ParseFormat::XML => unsafe {
@@ -97,7 +98,8 @@ impl Parser {
       ParseFormat::HTML => {
         // TODO: Allow user-specified options later on
         unsafe {
-          let options: i32 = HtmlParserOption::Recover as i32 + HtmlParserOption::Noerror as i32
+          let options: i32 = HtmlParserOption::Recover as i32
+            + HtmlParserOption::Noerror as i32
             + HtmlParserOption::Nowarning as i32;
           xmlKeepBlanksDefault(1);
           let docptr = htmlReadFile(c_filename.as_ptr(), c_utf8.as_ptr(), options);
@@ -118,7 +120,8 @@ impl Parser {
     let c_url = CString::new("").unwrap();
     match self.format {
       ParseFormat::XML => unsafe {
-        let options: i32 = XmlParserOption::Recover as i32 + XmlParserOption::Noerror as i32
+        let options: i32 = XmlParserOption::Recover as i32
+          + XmlParserOption::Noerror as i32
           + XmlParserOption::Nowarning as i32;
         let docptr = xmlReadDoc(
           c_string.as_bytes().as_ptr(),
@@ -133,7 +136,8 @@ impl Parser {
         }
       },
       ParseFormat::HTML => unsafe {
-        let options: i32 = HtmlParserOption::Recover as i32 + HtmlParserOption::Noerror as i32
+        let options: i32 = HtmlParserOption::Recover as i32
+          + HtmlParserOption::Noerror as i32
           + HtmlParserOption::Nowarning as i32;
         let docptr = htmlReadDoc(
           c_string.as_bytes().as_ptr(),

--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -20,7 +20,7 @@ pub(crate) type DocumentRef = Rc<RefCell<_Document>>;
 #[derive(Debug)]
 pub(crate) struct _Document {
   /// pointer to a libxml document
-  doc_ptr: xmlDocPtr,
+  pub(crate) doc_ptr: xmlDocPtr,
   /// hashed pointer-to-Node bookkeeping table
   nodes: HashMap<xmlNodePtr, Node>,
 }

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -736,10 +736,7 @@ impl Node {
   /// find nodes via xpath, at a specified node or the document root
   pub fn findnodes(&self, xpath: &str) -> Result<Vec<Node>, ()> {
     let docref = self.0.borrow().document.clone();
-    let mut context = Context::new_ptr(docref).unwrap();
-
-    try!(context.set_context_node(&self));
-    let evaluated = try!(context.evaluate(xpath));
-    Ok(evaluated.get_nodes_as_vec())
+    let mut context = Context::new_ptr(docref)?;
+    context.findnodes(xpath, Some(self))
   }
 }

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -15,6 +15,7 @@ use std::str;
 use tree::document::{Document, DocumentRef};
 use tree::namespace::Namespace;
 use tree::nodetype::NodeType;
+use xpath::Context;
 
 use bindings::*;
 use c_helpers::*;
@@ -730,5 +731,15 @@ impl Node {
   /// internal helper to ensure the node is marked as unlinked/removed from the main document tree
   fn set_unlinked(&mut self) {
     self.0.borrow_mut().unlinked = true;
+  }
+
+  /// find nodes via xpath, at a specified node or the document root
+  pub fn findnodes(&self, xpath: &str) -> Result<Vec<Node>, ()> {
+    let docref = self.0.borrow().document.clone();
+    let mut context = Context::new_ptr(docref).unwrap();
+
+    try!(context.set_context_node(&self));
+    let evaluated = try!(context.evaluate(xpath));
+    Ok(evaluated.get_nodes_as_vec())
   }
 }

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -105,18 +105,18 @@ impl Context {
   /// find nodes via xpath, at a specified node or the document root
   pub fn findnodes(&mut self, xpath: &str, node_opt: Option<&Node>) -> Result<Vec<Node>, ()> {
     if let Some(node) = node_opt {
-      try!(self.set_context_node(node));
+      self.set_context_node(node)?;
     }
-    let evaluated = try!(self.evaluate(xpath));
+    let evaluated = self.evaluate(xpath)?;
     Ok(evaluated.get_nodes_as_vec())
   }
 
   /// find a literal value via xpath, at a specified node or the document root
   pub fn findvalue(&mut self, xpath: &str, node_opt: Option<&Node>) -> Result<String, ()> {
     if let Some(node) = node_opt {
-      try!(self.set_context_node(node));
+      self.set_context_node(node)?;
     }
-    let evaluated = try!(self.evaluate(xpath));
+    let evaluated = self.evaluate(xpath)?;
     Ok(evaluated.to_string())
   }
 }

--- a/tests/xpath_tests.rs
+++ b/tests/xpath_tests.rs
@@ -125,3 +125,27 @@ fn xpath_string_function() {
   let content = p.to_string();
   assert_eq!(content, "value");
 }
+
+#[test]
+/// Test that the dual findnodes interfaces are operational
+fn findnodes_interfaces() {
+  let parser = Parser::default_html();
+  let doc_result = parser.parse_file("tests/resources/file02.xml");
+  assert!(doc_result.is_ok());
+  let doc = doc_result.unwrap();
+
+  // Xpath interface
+  let mut context = Context::new(&doc).unwrap();
+  let body = context.evaluate("/html/body").unwrap().get_nodes_as_vec();
+  let p_result = context.findnodes("p", body.first());
+  assert!(p_result.is_ok());
+  let p = p_result.unwrap();
+  assert_eq!(p.len(), 1);
+
+  // Node interface
+  let body_node = body.first().unwrap();
+  let p2_result = body_node.findnodes("p");
+  assert!(p2_result.is_ok());
+  let p2 = p2_result.unwrap();
+  assert_eq!(p2.len(), 1);
+}


### PR DESCRIPTION
This came up in my recent work, I need a direct `node.findnodes()` call without having to worry about reusing a document-level context.

Allowed for refactoring a bit the Context struct, now using the more correct `DocumentRef` object, and staying away from the rather elaborate Document drop logic.

Added a couple of findnodes tests, and valgrind seems happy that no memory is leaked. So I'll just ship a minor release and take it from there.