### PR TITLE
Node::null, and clippy lints

### DIFF
--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -81,6 +81,14 @@ impl Document {
     };
     Document(Rc::new(RefCell::new(doc)))
   }
+
+  pub(crate) fn null_ref() -> DocumentRef {
+    Rc::new(RefCell::new(_Document {
+      doc_ptr: ptr::null_mut(),
+      nodes: HashMap::new(),
+    }))
+  }
+
   /// Write document to `filename`
   pub fn save_file(&self, filename: &str) -> Result<c_int, ()> {
     let c_filename = CString::new(filename).unwrap();
@@ -94,7 +102,7 @@ impl Document {
   }
 
   pub(crate) fn register_node(&self, node_ptr: xmlNodePtr) -> Node {
-    Node::wrap(node_ptr, self.0.clone())
+    Node::wrap(node_ptr, &self.0)
   }
 
   /// Get the root element of the document

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -54,7 +54,7 @@ impl Context {
       })
     }
   }
-  pub(crate) fn new_ptr(docref: DocumentRef) -> Result<Context, ()> {
+  pub(crate) fn new_ptr(docref: &DocumentRef) -> Result<Context, ()> {
     let ctxtptr = unsafe { xmlXPathNewContext(docref.borrow().doc_ptr) };
     if ctxtptr.is_null() {
       Err(())
@@ -75,7 +75,7 @@ impl Context {
   /// Note: the Context is root-level for that document, use `.set_context_node` to limit scope to this node
   pub fn from_node(node: &Node) -> Result<Context, ()> {
     let docref = node.get_docref().upgrade().unwrap();
-    Context::new_ptr(docref)
+    Context::new_ptr(&docref)
   }
 
   /// Register a namespace prefix-href pair on the xpath context
@@ -194,11 +194,11 @@ impl Object {
     } else {
       Vec::new()
     };
-    for ptr in slice.into_iter() {
+    for ptr in slice {
       if ptr.is_null() {
         panic!("rust-libxml: xpath: found null pointer result set");
       }
-      let node = Node::wrap(ptr, self.document.upgrade().unwrap());
+      let node = Node::wrap(ptr, &self.document.upgrade().unwrap());
       vec.push(node);
     }
     vec

--- a/tests/VALGRIND.md
+++ b/tests/VALGRIND.md
@@ -1,0 +1,22 @@
+It is often good practice, especially when venturing on large API refactors, to double-check for any newly created memory leaks.
+
+Some leaks can only be spotted in external projects that show advance use cases of `rust-libxml`, for example allocating a `Node` in a default trait of a struct with a `Node` field. For now the only safe approach to that pattern is using the `Node::null()` placeholder, but the Rust idiomatic approach is to instead refactor to an `Option<Node>` field.
+
+Some, more direct, leak scenarios can already be spotted from the libxml test suite, and one can use valgrind to obtain a report via a call of the form:
+
+```
+  valgrind --leak-check=full target/debug/base_tests-3d29e5da1f969267
+```
+
+Additionally, as Rust nightlies keep evolving, a specific allocation system may be necessary to properly run valgrind. At the time of writing, `rust-libxml` tests need no such changes, but some external projects do. For convenience, here is a known working preamble, which can be added to the preambles of executable files, including example and test files.
+
+```rust
+#![feature(alloc_system, allocator_api)]
+extern crate alloc_system;
+use alloc_system::System;
+
+#[global_allocator]
+static A: System = System;
+```
+
+For more discussion motivating this explanation, see the respective [GitHub pull request](https://github.com/KWARC/rust-libxml/pull/43).

--- a/tests/tree_tests.rs
+++ b/tests/tree_tests.rs
@@ -215,6 +215,16 @@ fn can_hash_mock_node() {
 }
 
 #[test]
+/// Can make null nodes and documents, to avoid memory allocations
+fn can_null_node() {
+  let null_node = Node::null();
+  let second_null_node = Node::null();
+  assert!(null_node.is_null());
+  assert!(second_null_node.is_null());
+  assert_eq!(null_node, second_null_node);
+}
+
+#[test]
 /// Can set and get attributes
 fn can_manage_attributes() {
   let mut doc = Document::new().unwrap();


### PR DESCRIPTION
cc @triptec - another one to review.

I got lucky and found the trick to running valgrind in my other project (which keeps evolving as new features appear in nightly), more in [the issue](https://github.com/KWARC/llamapun/issues/20) for anyone interested.

And that revealed that using `Node::mock()` in an implementation of the `Default` trait is leaking memory - albeit tiny amounts.

So in this PR I finally did the C approach properly - I added `Node::null()` method, which uses a `ptr::null_mut`, and added an internal sibling of that method for `DocumentRef`. So now there is a memory-free placeholder node, which is more appropriate for my use case.

One could argue that the other project has an API mistake, and should really use an `Option<Node>` instead, but that makes the entire API way too cumbersome. In fact what I really want is a `PartialDefault` trait, as I would love to provide fallbacks for all fields except the node... But that's a brainstorm for another day.

I also added some recent clippy lint suggestions, and a new test. And naturally verified that no memory is leaked after refactoring to using `Node::null()`, which is happily indeed the case.