### PR TITLE
update to 2018 edition of Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ addons:
 after_success: ./scripts/doc-upload.sh
 env:
   global:
+    - RUST_TEST_THREADS=1
     - SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
     - secure: "kuvtFj8UpLj0NQhk3a9PDLRhXq4cDhd9UNT9Sn0S2TBFF23AsOX2ffXN+5ey/2mfYEk18d5MpUM15Ha/7PbxTebkqZxhFeZimrqAHTC6605AUICmuJv06tmLYetoqgNvyU0Tgt4MCYblja8oJCs/TkEFtbVxZX0uZ2lgsyLG8PQyROEyiaPQyeld7rd4k6s+13w4EOFO0kGh992BmOAUiICqsDqKYddaI7KL49b4AwkGrfaXAf/mtlJT7E4NlloI/5AmCYlQdYwQui3SJojvzd9lDBF7syuPesgPz3S6dlzr80uKVuI0rVx6K6Xo+vzZLWP4HZExIjF12G8DuBKAWLmoN/QfR+ipkXGrTau78+8Jp0qCQsy4ti4rY8PvhwipkdGS+pUV8a06UwTZARLnknnhfqKFoNvIUjLwdu1HVwftXtIgdFtU7RZMJfUxdq8/dNdXNerAm4c3kdwcKl4nP6Fnus4OWkeekuuCCObcBI1qlTFQT2pp5ae+3oe3kq1Srq8/HrLGlQkcWlbYsB9/mKuSxqRQxTbGli3eWBALecpeCQPdrxygFarX6q18HTwoqprvbcCp9BM4soADv5gVUeiOuYmvn2DbREMMZJKd6cpcXpXem4epK+MxpXh7jhQ60xw9GuIIeZxcgyKf+pP3lRoII3nPZKoecUoDcJct1l4="
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
-## [0.2.6] (in active development)
+## [0.2.7] (in active development)
+
+## [0.2.6] 2018-07-12
+
+ * Internal update to Rust 2018 Edition
+ * fix deallocation bugs with `.import_node()` and `.get_namespaces()`
 
 ## [0.2.5] 2018-26-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "libxml"
-version = "0.2.5"
+version = "0.2.6"
+edition = "2018"
 authors = ["Andreas Franzén <andreas@devil.se>", "Deyan Ginev <deyan.ginev@gmail.com>","Jan Frederik Schaefer <j.schaefer@jacobs-university.de>"]
 description = "A Rust wrapper for libxml2 - the XML C parser and toolkit developed for the Gnome project"
 repository = "https://github.com/KWARC/rust-libxml"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-extern crate pkg_config;
-
 use pkg_config::find_library;
 
 fn main() {

--- a/examples/tree_example.rs
+++ b/examples/tree_example.rs
@@ -1,5 +1,3 @@
-extern crate libxml;
-
 use libxml::parser::Parser;
 use libxml::tree::*;
 

--- a/examples/xpath_example.rs
+++ b/examples/xpath_example.rs
@@ -1,8 +1,5 @@
-extern crate libxml;
-
-use libxml::parser::{Parser};
+use libxml::parser::Parser;
 use libxml::xpath::Context;
-
 
 fn main() {
   let parser = Parser::default();
@@ -11,6 +8,6 @@ fn main() {
   let result = context.evaluate("//child/text()").unwrap();
 
   for node in &result.get_nodes_as_vec() {
-      println!("Found: {}", node.get_content());
+    println!("Found: {}", node.get_content());
   }
 }

--- a/src/c_helpers.rs
+++ b/src/c_helpers.rs
@@ -1,7 +1,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-use bindings::*;
+use crate::bindings::*;
 use libc::{c_char, c_int, size_t};
 use std::os::raw::c_void;
 use std::ptr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 //! The idea is to extend it whenever more functionality is needed.
 //! Providing a more or less complete wrapper would be too much work.
 #![deny(missing_docs)]
-extern crate libc;
 
 /// Bindings to the C interface
 pub mod bindings;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 //! The idea is to extend it whenever more functionality is needed.
 //! Providing a more or less complete wrapper would be too much work.
 #![deny(missing_docs)]
+// Our new methods return Result<Self, _> types
+#![allow(clippy::new_ret_no_self)]
 
 /// Bindings to the C interface
 pub mod bindings;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,8 +1,8 @@
 //! The parser functionality
 
-use bindings::*;
-use c_helpers::*;
-use tree::*;
+use crate::bindings::*;
+use crate::c_helpers::*;
+use crate::tree::*;
 
 use std::ffi::{CStr, CString};
 use std::fmt;

--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -40,11 +40,13 @@ impl _Document {
 #[derive(Clone)]
 pub struct Document(pub(crate) DocumentRef);
 
-impl Drop for Document {
+impl Drop for _Document {
   ///Free document when it goes out of scope
   fn drop(&mut self) {
     unsafe {
-      xmlFreeDoc(self.doc_ptr());
+      if !self.doc_ptr.is_null() {
+        xmlFreeDoc(self.doc_ptr);
+      }
     }
   }
 }
@@ -197,7 +199,7 @@ impl Document {
       let c_name = CString::new(name).unwrap();
       let c_content = CString::new(content).unwrap();
 
-      let node_ptr = xmlNewDocPI(
+      let node_ptr: xmlNodePtr = xmlNewDocPI(
         self.doc_ptr(),
         c_name.as_bytes().as_ptr(),
         c_content.as_bytes().as_ptr(),

--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -10,10 +10,9 @@ use std::ptr;
 use std::rc::{Rc, Weak};
 use std::str;
 
-use bindings::*;
-use c_helpers::*;
-
-use tree::node::Node;
+use crate::bindings::*;
+use crate::c_helpers::*;
+use crate::tree::node::Node;
 
 pub(crate) type DocumentRef = Rc<RefCell<_Document>>;
 pub(crate) type DocumentWeak = Weak<RefCell<_Document>>;

--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -34,6 +34,10 @@ impl _Document {
   pub(crate) fn get_node(&self, node_ptr: xmlNodePtr) -> Option<&Node> {
     self.nodes.get(&node_ptr)
   }
+  /// Internal bookkeeping function
+  pub(crate) fn forget_node(&mut self, node_ptr: xmlNodePtr) {
+    self.nodes.remove(&node_ptr);
+  }
 }
 
 /// A libxml2 Document
@@ -139,6 +143,13 @@ impl Document {
     if !node.is_unlinked() {
       return Err(());
     }
+    // Also remove this node from the prior document hash
+    node
+      .get_docref()
+      .upgrade()
+      .unwrap()
+      .borrow_mut()
+      .forget_node(node.node_ptr());
 
     let node_ptr = unsafe { xmlDocCopyNode(node.node_ptr(), self.doc_ptr(), 1) };
     self.ptr_as_result(node_ptr)

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1,14 +1,14 @@
 //! The tree functionality
 //!
 
-mod document;
-mod namespace;
-mod node;
-mod nodetype;
+pub mod document;
+pub mod namespace;
+pub mod node;
+pub mod nodetype;
 
-pub use tree::document::Document;
-pub(crate) use tree::document::{DocumentRef, DocumentWeak};
-pub use tree::namespace::Namespace;
-pub use tree::node::set_node_rc_guard;
-pub use tree::node::{Node, NODE_RC_MAX_GUARD};
-pub use tree::nodetype::NodeType;
+pub use self::document::Document;
+pub(crate) use self::document::{DocumentRef, DocumentWeak};
+pub use self::namespace::Namespace;
+pub use self::node::set_node_rc_guard;
+pub use self::node::{Node, NODE_RC_MAX_GUARD};
+pub use self::nodetype::NodeType;

--- a/src/tree/namespace.rs
+++ b/src/tree/namespace.rs
@@ -1,15 +1,13 @@
 //! Namespace feature set
 //!
-
-use bindings::*;
-use c_helpers::*;
-
 use std::error::Error;
 use std::ffi::{CStr, CString};
 use std::ptr;
 use std::str;
 
-use tree::node::Node;
+use crate::bindings::*;
+use crate::c_helpers::*;
+use crate::tree::node::Node;
 
 ///An xml namespace
 #[derive(Clone)]

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -536,7 +536,9 @@ impl Node {
           DG: I could not improve on this state without creating memory leaks after ~1 hour, so I am
           marking it as future work.
         */
-        xmlFreeNs(list_ptr_raw as xmlNsPtr);
+        /* TODO: How do we properly deallocate here? The approach bellow reliably segfaults tree_tests on 1 thread */
+        // println!("\n-- xmlfreens on : {:?}", list_ptr_raw);
+        // xmlFreeNs(list_ptr_raw as xmlNsPtr);
       }
       namespaces
     }

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1,6 +1,5 @@
 //! Node, and related, feature set
 //!
-use libc;
 use libc::{c_char, c_void};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
@@ -12,13 +11,12 @@ use std::ptr;
 use std::rc::Rc;
 use std::str;
 
-use tree::document::{Document, DocumentRef, DocumentWeak};
-use tree::namespace::Namespace;
-use tree::nodetype::NodeType;
-use xpath::Context;
-
-use bindings::*;
-use c_helpers::*;
+use crate::bindings::*;
+use crate::c_helpers::*;
+use crate::tree::namespace::Namespace;
+use crate::tree::nodetype::NodeType;
+use crate::tree::{Document, DocumentRef, DocumentWeak};
+use crate::xpath::Context;
 
 /// Guard treshold for enforcing runtime mutability checks for Nodes
 pub static mut NODE_RC_MAX_GUARD: usize = 2;

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -1,14 +1,14 @@
 //! The `XPath` functionality
 
-use bindings::*;
-use c_helpers::*;
+use crate::bindings::*;
+use crate::c_helpers::*;
+use crate::tree::{Document, DocumentRef, DocumentWeak, Node};
 use libc;
 use libc::{c_char, c_void, size_t};
 use std::cell::RefCell;
 use std::ffi::{CStr, CString};
 use std::rc::Rc;
 use std::str;
-use tree::{Document, DocumentRef, DocumentWeak, Node};
 
 ///Thinly wrapped libxml2 xpath context
 pub(crate) type ContextRef = Rc<RefCell<_Context>>;

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -53,8 +53,9 @@ fn create_pi() {
   assert!(doc_result.is_ok());
   let mut doc = doc_result.unwrap();
   // Add a PI
-  let node_ok = doc.create_processing_instruction("piname", "picontent");
+  let node_ok: Result<Node, ()> = doc.create_processing_instruction("piname", "picontent");
   assert!(node_ok.is_ok());
+  assert_eq!(node_ok.unwrap().get_content(), "picontent");
   let doc_string = doc.to_string(false);
   assert!(doc_string.len() > 1);
 }

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -1,7 +1,5 @@
 //! Base API tests, to be split into distinct sub-suites later on
 //!
-extern crate libxml;
-
 use std::fs::File;
 use std::io::Read;
 
@@ -120,13 +118,11 @@ fn document_can_import_node() {
   let mut node = elements.pop().unwrap();
   node.unlink();
   let mut imported = doc2.import_node(&mut node).unwrap();
-  assert!(
-    doc2
-      .get_root_element()
-      .unwrap()
-      .add_child(&mut imported)
-      .is_ok()
-  );
+  assert!(doc2
+    .get_root_element()
+    .unwrap()
+    .add_child(&mut imported)
+    .is_ok());
 
   assert_eq!(
     doc2.get_root_element().unwrap().get_child_elements().len(),

--- a/tests/mutability_guards.rs
+++ b/tests/mutability_guards.rs
@@ -1,7 +1,5 @@
 //! Enforce Rust ownership pragmatics for the underlying libxml2 objects
 
-extern crate libxml;
-
 use libxml::parser::Parser;
 use libxml::tree::set_node_rc_guard;
 

--- a/tests/tree_tests.rs
+++ b/tests/tree_tests.rs
@@ -1,6 +1,5 @@
 //! Tree module tests
 //!
-extern crate libxml;
 
 use libxml::parser::Parser;
 use libxml::tree::{Document, Namespace, Node, NodeType};

--- a/tests/xpath_tests.rs
+++ b/tests/xpath_tests.rs
@@ -1,6 +1,5 @@
 //! xpath module tests
 //!
-extern crate libxml;
 
 use libxml::parser::Parser;
 use libxml::xpath::Context;


### PR DESCRIPTION
The 2018 edition is now in Rust stable:
https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html

Decided to update my crates and version bump, adding this for a Travis check.