### PR TITLE
Thread-safe via `Arc<Mutex<...>>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,22 @@ license = "MIT"
 keywords = ["xml", "libxml","xpath", "parser", "parsing", "html"]
 build = "build.rs"
 exclude = [
-  "scripts/*"
+  "scripts/*","benches/*"
 ]
+
+[lib]
+name = "libxml"
 
 [dependencies]
 libc = "0.2"
-rayon = "1.0.0"
 
 [build-dependencies]
 pkg-config = "0.3.2"
 
-[lib]
-name = "libxml"
+[dev-dependencies]
+rayon = "1.0.0"
+criterion = "0.2.10"
+
+[[bench]]
+name = "parsing_benchmarks"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [
 
 [dependencies]
 libc = "0.2"
+rayon = "1.0.0"
 
 [build-dependencies]
 pkg-config = "0.3.2"

--- a/benches/parsing_benchmarks.rs
+++ b/benches/parsing_benchmarks.rs
@@ -3,8 +3,12 @@ extern crate criterion;
 
 use criterion::Criterion;
 use libxml::parser::Parser;
-use libxml::tree::Node;
+use libxml::tree::{Node, NodeType};
 use rayon::prelude::*;
+
+// -- workhorse functions
+// not *quite* classic depth-first search, since we keep all children at the current level in memory,
+// but certainly DFS-order for traversal
 
 fn dfs_single(node: Node) -> i32 {
   1 + node
@@ -22,10 +26,37 @@ fn dfs_parallel(node: Node) -> i32 {
     .sum::<i32>()
 }
 
+fn dfs_single_work2(node: Node) -> (i32, usize) {
+  if node.get_type() == Some(NodeType::TextNode) {
+    (1, node.get_content().len())
+  } else {
+    node
+      .get_child_nodes()
+      .into_iter()
+      .map(dfs_single_work2)
+      .fold((1, 0), |acc, x| (acc.0 + x.0, acc.1 + x.1))
+  }
+}
+
+fn dfs_parallel_work2(node: Node) -> (i32, usize) {
+  if node.get_type() == Some(NodeType::TextNode) {
+    (1, node.get_content().len())
+  } else {
+    let dfs_work = node
+      .get_child_nodes()
+      .into_par_iter()
+      .map(dfs_parallel_work2)
+      .reduce(|| (0, 0), |acc, x| (acc.0 + x.0, acc.1 + x.1));
+    (dfs_work.0 + 1, dfs_work.1)
+  }
+}
+
+// --- bencher functions
+
 fn bench_single_thread(c: &mut Criterion) {
   let parser = Parser::default();
   let doc = parser.parse_file("benches/big.xml").unwrap();
-  c.bench_function("single thread", move |b| {
+  c.bench_function("single thread DFS count", move |b| {
     b.iter(|| {
       let root = doc.get_root_element().unwrap();
       assert_eq!(dfs_single(root), 4_690_647)
@@ -33,10 +64,21 @@ fn bench_single_thread(c: &mut Criterion) {
   });
 }
 
+fn bench_single_thread_work2(c: &mut Criterion) {
+  let parser = Parser::default();
+  let doc = parser.parse_file("benches/big.xml").unwrap();
+  c.bench_function("single thread DFS count+length", move |b| {
+    b.iter(|| {
+      let root = doc.get_root_element().unwrap();
+      assert_eq!(dfs_single_work2(root), (4_690_647, 81_286_567))
+    })
+  });
+}
+
 fn bench_multi_thread(c: &mut Criterion) {
   let parser = Parser::default();
   let doc = parser.parse_file("benches/big.xml").unwrap();
-  c.bench_function("multi thread", move |b| {
+  c.bench_function("multi thread DFS count", move |b| {
     b.iter(|| {
       let root = doc.get_root_element().unwrap();
       assert_eq!(dfs_parallel(root), 4_690_647);
@@ -44,9 +86,73 @@ fn bench_multi_thread(c: &mut Criterion) {
   });
 }
 
+fn bench_multi_thread_work2(c: &mut Criterion) {
+  let parser = Parser::default();
+  let doc = parser.parse_file("benches/big.xml").unwrap();
+  c.bench_function("multi thread DFS count+length", move |b| {
+    b.iter(|| {
+      let root = doc.get_root_element().unwrap();
+      assert_eq!(dfs_parallel_work2(root), (4_690_647, 81_286_567))
+    })
+  });
+}
 criterion_group!(
   name = benches;
   config = Criterion::default().sample_size(10);
-  targets = bench_single_thread, bench_multi_thread
+  targets = bench_single_thread, bench_single_thread_work2, bench_multi_thread, bench_multi_thread_work2
 );
+
 criterion_main!(benches);
+
+// -- Results on @dginev's machine, big.xml
+//    controlling thread count via "RAYON_NUM_THREADS=X cargo bench"
+// ---
+// 32 threads:
+// ---
+// multi thread DFS count  time:   [4.6973 s 4.7191 s 4.7351 s]
+// multi thread DFS count+length
+//                         time:   [4.6695 s 4.6784 s 4.6864 s]
+// ---
+// 16 threads (compared to 32 threads):
+// ---
+// multi thread DFS count  time:   [4.3077 s 4.3226 s 4.3503 s]
+//                         change: [-9.2711% -8.5028% -7.6743%] (p = 0.00 < 0.05)
+// multi thread DFS count+length
+//                         time:   [4.3969 s 4.4199 s 4.4400 s]
+//                         change: [-6.2258% -5.7250% -5.2269%] (p = 0.00 < 0.05)
+// ---
+// 8 threads (compared to 16 threads):
+// ---
+// multi thread DFS count  time:   [4.6934 s 4.7066 s 4.7236 s]
+//                         change: [+8.0596% +8.9386% +9.6914%] (p = 0.00 < 0.05)
+// multi thread DFS count+length
+//                         time:   [4.2944 s 4.3431 s 4.3800 s]
+//                         change: [-2.9167% -1.8463% -0.7335%] (p = 0.00 < 0.05)
+// ---
+// 4 threads (compared to 8 threads):
+// ---
+// multi thread DFS count  time:   [3.9458 s 4.0396 s 4.1157 s]
+//                         change: [-17.660% -15.890% -14.159%] (p = 0.00 < 0.05)
+// multi thread DFS count+length
+//                         time:   [3.8821 s 3.9815 s 4.0516 s]
+//                         change: [-9.2847% -7.1400% -5.1074%] (p = 0.00 < 0.05)
+// ---
+// 2 threads (compared to 4 threads):
+// ---
+// multi thread DFS count  time:   [3.1924 s 3.2423 s 3.2986 s]
+//                         change: [-20.691% -18.659% -16.551%] (p = 0.00 < 0.05)
+// multi thread DFS count+length
+//                         time:   [3.2541 s 3.4244 s 3.4956 s]
+//                         change: [-24.243% -19.735% -15.510%] (p = 0.00 < 0.05)
+// ---
+// 1 thread (compared to 2 threads):
+// ---
+// multi thread DFS count  time:   [1.5219 s 1.5240 s 1.5262 s]
+//                         change: [-53.428% -52.788% -52.130%] (p = 0.00 < 0.05)
+// multi thread DFS count+length
+//                         time:   [1.7658 s 1.7708 s 1.7761 s]
+//                         change: [-47.766% -45.000% -41.973%] (p = 0.00 < 0.05)
+// ---
+// single thread DFS count time:   [1.4969 s 1.4997 s 1.5049 s]
+// single thread DFS count+length
+//                         time:   [1.7236 s 1.7319 s 1.7404 s]

--- a/benches/parsing_benchmarks.rs
+++ b/benches/parsing_benchmarks.rs
@@ -1,0 +1,52 @@
+#[macro_use]
+extern crate criterion;
+
+use criterion::Criterion;
+use libxml::parser::Parser;
+use libxml::tree::Node;
+use rayon::prelude::*;
+
+fn dfs_single(node: Node) -> i32 {
+  1 + node
+    .get_child_nodes()
+    .into_iter()
+    .map(dfs_single)
+    .sum::<i32>()
+}
+
+fn dfs_parallel(node: Node) -> i32 {
+  1 + node
+    .get_child_nodes()
+    .into_par_iter()
+    .map(dfs_parallel)
+    .sum::<i32>()
+}
+
+fn bench_single_thread(c: &mut Criterion) {
+  let parser = Parser::default();
+  let doc = parser.parse_file("benches/big.xml").unwrap();
+  c.bench_function("single thread", move |b| {
+    b.iter(|| {
+      let root = doc.get_root_element().unwrap();
+      assert_eq!(dfs_single(root), 4_690_647)
+    })
+  });
+}
+
+fn bench_multi_thread(c: &mut Criterion) {
+  let parser = Parser::default();
+  let doc = parser.parse_file("benches/big.xml").unwrap();
+  c.bench_function("multi thread", move |b| {
+    b.iter(|| {
+      let root = doc.get_root_element().unwrap();
+      assert_eq!(dfs_parallel(root), 4_690_647);
+    })
+  });
+}
+
+criterion_group!(
+  name = benches;
+  config = Criterion::default().sample_size(10);
+  targets = bench_single_thread, bench_multi_thread
+);
+criterion_main!(benches);

--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -3,19 +3,18 @@
 
 use libc;
 use libc::{c_char, c_int, c_void};
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::ptr;
-use std::sync::{Arc, Weak, Mutex};
 use std::str;
+use std::sync::{Arc, Mutex, Weak};
 
 use crate::bindings::*;
 use crate::c_helpers::*;
 use crate::tree::node::Node;
 
-pub(crate) type DocumentRef = Arc<Mutex<RefCell<_Document>>>;
-pub(crate) type DocumentWeak = Weak<Mutex<RefCell<_Document>>>;
+pub(crate) type DocumentRef = Arc<Mutex<_Document>>;
+pub(crate) type DocumentWeak = Weak<Mutex<_Document>>;
 
 #[derive(Debug)]
 pub(crate) struct _Document {
@@ -68,14 +67,14 @@ impl Document {
           doc_ptr,
           nodes: HashMap::new(),
         };
-        Ok(Document(Arc::new(Mutex::new(RefCell::new(doc)))))
+        Ok(Document(Arc::new(Mutex::new(doc))))
       }
     }
   }
 
   /// Obtain the underlying libxml2 `xmlDocPtr` for this Document
   pub fn doc_ptr(&self) -> xmlDocPtr {
-    self.0.lock().unwrap().borrow().doc_ptr
+    self.0.lock().unwrap().doc_ptr
   }
 
   /// Creates a new `Document` from an existing libxml2 pointer
@@ -84,14 +83,14 @@ impl Document {
       doc_ptr,
       nodes: HashMap::new(),
     };
-    Document(Arc::new(Mutex::new(RefCell::new(doc))))
+    Document(Arc::new(Mutex::new(doc)))
   }
 
   pub(crate) fn null_ref() -> DocumentRef {
-    Arc::new(Mutex::new(RefCell::new(_Document {
+    Arc::new(Mutex::new(_Document {
       doc_ptr: ptr::null_mut(),
       nodes: HashMap::new(),
-    })))
+    }))
   }
 
   /// Write document to `filename`
@@ -150,7 +149,6 @@ impl Document {
       .unwrap()
       .lock()
       .unwrap()
-      .borrow_mut()
       .forget_node(node.node_ptr());
 
     let node_ptr = unsafe { xmlDocCopyNode(node.node_ptr(), self.doc_ptr(), 1) };
@@ -245,7 +243,7 @@ impl Document {
         doc_ptr,
         nodes: HashMap::new(),
       };
-      Ok(Document(Arc::new(Mutex::new(RefCell::new(doc)))))
+      Ok(Document(Arc::new(Mutex::new(doc))))
     }
   }
 
@@ -259,7 +257,7 @@ impl Document {
     if doc_ptr.is_null() {
       return Err(());
     }
-    self.0.lock().unwrap().borrow_mut().doc_ptr = doc_ptr;
+    self.0.lock().unwrap().doc_ptr = doc_ptr;
     Ok(())
   }
 }

--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -7,14 +7,14 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::ptr;
-use std::rc::{Rc, Weak};
+use std::sync::{Arc, Weak};
 use std::str;
 
 use crate::bindings::*;
 use crate::c_helpers::*;
 use crate::tree::node::Node;
 
-pub(crate) type DocumentRef = Rc<RefCell<_Document>>;
+pub(crate) type DocumentRef = Arc<RefCell<_Document>>;
 pub(crate) type DocumentWeak = Weak<RefCell<_Document>>;
 
 #[derive(Debug)]
@@ -68,7 +68,7 @@ impl Document {
           doc_ptr,
           nodes: HashMap::new(),
         };
-        Ok(Document(Rc::new(RefCell::new(doc))))
+        Ok(Document(Arc::new(RefCell::new(doc))))
       }
     }
   }
@@ -84,11 +84,11 @@ impl Document {
       doc_ptr,
       nodes: HashMap::new(),
     };
-    Document(Rc::new(RefCell::new(doc)))
+    Document(Arc::new(RefCell::new(doc)))
   }
 
   pub(crate) fn null_ref() -> DocumentRef {
-    Rc::new(RefCell::new(_Document {
+    Arc::new(RefCell::new(_Document {
       doc_ptr: ptr::null_mut(),
       nodes: HashMap::new(),
     }))
@@ -243,7 +243,7 @@ impl Document {
         doc_ptr,
         nodes: HashMap::new(),
       };
-      Ok(Document(Rc::new(RefCell::new(doc))))
+      Ok(Document(Arc::new(RefCell::new(doc))))
     }
   }
 

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -8,7 +8,7 @@ use std::ffi::{CStr, CString};
 use std::hash::{Hash, Hasher};
 use std::mem;
 use std::ptr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::str;
 
 use crate::bindings::*;
@@ -29,7 +29,7 @@ pub fn set_node_rc_guard(value: usize) {
   }
 }
 
-type NodeRef = Arc<RefCell<_Node>>;
+type NodeRef = Arc<Mutex<RefCell<_Node>>>;
 
 #[derive(Debug)]
 struct _Node {
@@ -44,6 +44,9 @@ struct _Node {
 /// An xml node
 #[derive(Clone, Debug)]
 pub struct Node(NodeRef);
+
+unsafe impl Sync for Node {}
+unsafe impl Send for Node {}
 
 impl Hash for Node {
   /// Generates a hash value from the `node_ptr` value.
@@ -103,7 +106,7 @@ impl Node {
 
   /// Immutably borrows the underlying libxml2 `xmlNodePtr` pointer
   pub fn node_ptr(&self) -> xmlNodePtr {
-    self.0.borrow().node_ptr
+    self.0.lock().unwrap().borrow().node_ptr
   }
 
   /// Mutably borrows the underlying libxml2 `xmlNodePtr` pointer
@@ -118,7 +121,7 @@ impl Node {
     // correct check would be to have a weak count of 0 and a strong count <=2 (one for self, one for .nodes)
     let guard_ok = unsafe { weak_count == 0 && strong_count <= NODE_RC_MAX_GUARD };
     if guard_ok {
-      Ok(self.0.borrow_mut().node_ptr)
+      Ok(self.0.lock().unwrap().borrow_mut().node_ptr)
     } else {
       Err(format!(
         "Can not mutably reference a shared Node {:?}! Rc: weak count: {:?}; strong count: {:?}",
@@ -132,7 +135,7 @@ impl Node {
   /// Wrap a libxml node ptr with a Node
   pub(crate) fn wrap(node_ptr: xmlNodePtr, document: &DocumentRef) -> Node {
     // If already seen, return saved Node
-    if let Some(node) = document.borrow().get_node(node_ptr) {
+    if let Some(node) = document.lock().unwrap().borrow().get_node(node_ptr) {
       return node.clone();
     }
     // If newly encountered pointer, wrap
@@ -141,8 +144,9 @@ impl Node {
       document: Arc::downgrade(&document),
       unlinked: false,
     };
-    let wrapped_node = Node(Arc::new(RefCell::new(node)));
+    let wrapped_node = Node(Arc::new(Mutex::new(RefCell::new(node))));
     document
+      .lock().unwrap()
       .borrow_mut()
       .insert_node(node_ptr, wrapped_node.clone());
     wrapped_node
@@ -168,11 +172,11 @@ impl Node {
 
   /// Create a mock node, used for a placeholder argument
   pub fn null() -> Self {
-    Node(Arc::new(RefCell::new(_Node {
+    Node(Arc::new(Mutex::new(RefCell::new(_Node {
       node_ptr: ptr::null_mut(),
       document: Arc::downgrade(&Document::null_ref()),
       unlinked: true,
-    })))
+    }))))
   }
 
   /// `libc::c_void` isn't hashable and cannot be made hashable
@@ -181,7 +185,7 @@ impl Node {
   }
 
   pub(crate) fn get_docref(&self) -> DocumentWeak {
-    self.0.borrow().document.clone()
+    self.0.lock().unwrap().borrow().document.clone()
   }
 
   /// Returns the next sibling if it exists
@@ -732,7 +736,7 @@ impl Node {
 
   /// Checks if node is marked as unlinked
   pub fn is_unlinked(&self) -> bool {
-    self.0.borrow().unlinked
+    self.0.lock().unwrap().borrow().unlinked
   }
 
   fn ptr_as_option(&self, node_ptr: xmlNodePtr) -> Option<Node> {
@@ -747,12 +751,12 @@ impl Node {
 
   /// internal helper to ensure the node is marked as linked/imported/adopted in the main document tree
   fn set_linked(&mut self) {
-    self.0.borrow_mut().unlinked = false;
+    self.0.lock().unwrap().borrow_mut().unlinked = false;
   }
 
   /// internal helper to ensure the node is marked as unlinked/removed from the main document tree
   fn set_unlinked(&mut self) {
-    self.0.borrow_mut().unlinked = true;
+    self.0.lock().unwrap().borrow_mut().unlinked = true;
   }
 
   /// find nodes via xpath, at a specified node or the document root

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -5,13 +5,12 @@ use crate::c_helpers::*;
 use crate::tree::{Document, DocumentRef, DocumentWeak, Node};
 use libc;
 use libc::{c_char, c_void, size_t};
-use std::cell::RefCell;
 use std::ffi::{CStr, CString};
-use std::sync::{Mutex, Arc};
 use std::str;
+use std::sync::{Arc, Mutex};
 
 ///Thinly wrapped libxml2 xpath context
-pub(crate) type ContextRef = Arc<Mutex<RefCell<_Context>>>;
+pub(crate) type ContextRef = Arc<Mutex<_Context>>;
 
 #[derive(Debug)]
 pub(crate) struct _Context(pub(crate) xmlXPathContextPtr);
@@ -49,18 +48,18 @@ impl Context {
       Err(())
     } else {
       Ok(Context {
-        context_ptr: Arc::new(Mutex::new(RefCell::new(_Context(ctxtptr)))),
+        context_ptr: Arc::new(Mutex::new(_Context(ctxtptr))),
         document: Arc::downgrade(&doc.0),
       })
     }
   }
   pub(crate) fn new_ptr(docref: &DocumentRef) -> Result<Context, ()> {
-    let ctxtptr = unsafe { xmlXPathNewContext(docref.lock().unwrap().borrow().doc_ptr) };
+    let ctxtptr = unsafe { xmlXPathNewContext(docref.lock().unwrap().doc_ptr) };
     if ctxtptr.is_null() {
       Err(())
     } else {
       Ok(Context {
-        context_ptr: Arc::new(Mutex::new(RefCell::new(_Context(ctxtptr)))),
+        context_ptr: Arc::new(Mutex::new(_Context(ctxtptr))),
         document: Arc::downgrade(docref),
       })
     }
@@ -68,7 +67,7 @@ impl Context {
 
   /// Returns the raw libxml2 context pointer behind the struct
   pub fn as_ptr(&self) -> xmlXPathContextPtr {
-    self.context_ptr.lock().unwrap().borrow().0
+    self.context_ptr.lock().unwrap().0
   }
 
   /// Instantiate a new Context for the Document of a given Node.

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -7,11 +7,11 @@ use libc;
 use libc::{c_char, c_void, size_t};
 use std::cell::RefCell;
 use std::ffi::{CStr, CString};
-use std::rc::Rc;
+use std::sync::Arc;
 use std::str;
 
 ///Thinly wrapped libxml2 xpath context
-pub(crate) type ContextRef = Rc<RefCell<_Context>>;
+pub(crate) type ContextRef = Arc<RefCell<_Context>>;
 
 #[derive(Debug)]
 pub(crate) struct _Context(pub(crate) xmlXPathContextPtr);
@@ -49,8 +49,8 @@ impl Context {
       Err(())
     } else {
       Ok(Context {
-        context_ptr: Rc::new(RefCell::new(_Context(ctxtptr))),
-        document: Rc::downgrade(&doc.0),
+        context_ptr: Arc::new(RefCell::new(_Context(ctxtptr))),
+        document: Arc::downgrade(&doc.0),
       })
     }
   }
@@ -60,8 +60,8 @@ impl Context {
       Err(())
     } else {
       Ok(Context {
-        context_ptr: Rc::new(RefCell::new(_Context(ctxtptr))),
-        document: Rc::downgrade(&docref),
+        context_ptr: Arc::new(RefCell::new(_Context(ctxtptr))),
+        document: Arc::downgrade(&docref),
       })
     }
   }

--- a/tests/rayon_test.rs
+++ b/tests/rayon_test.rs
@@ -1,0 +1,27 @@
+use libxml::parser::Parser;
+use rayon::prelude::*;
+
+#[test]
+/// Root node and first child of root node are different
+/// (There is a tiny chance this might fail for a correct program)
+fn child_of_root_has_different_hash() {
+  let parser = Parser::default();
+  let doc_result = parser.parse_file("tests/resources/file01.xml");
+  assert!(doc_result.is_ok());
+  let doc = doc_result.unwrap();
+  let root = doc.get_root_element().unwrap();
+  assert!(!root.is_text_node());
+
+  root.get_child_nodes().into_par_iter().for_each(|mut child| {
+    assert!(root != child);
+    assert!(child.set_attribute("into_par_iter","true").is_ok());
+  });
+  let expected = r###"
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+    <child attribute="value" into_par_iter="true">some text</child>
+    <child attribute="empty" into_par_iter="true">more text</child>
+</root>
+    "###.trim();
+    assert_eq!(doc.to_string(true).trim(), expected);
+}


### PR DESCRIPTION
First stab at thread safety ( #46 ).

I would be quite lucky if you have some time to review and think about the general problem @triptec . Or if you know of other crates that may have solved a similar issue nicely, that we can copy a method from.

In this PR I added the "best practice" from the official rust book, which is to hide the libxml node pointer behind even more indirection+guarantees:

```rust
type NodeRef = Arc<Mutex<_Node>>;
```

And you could still pretend this is a regular rust data structure and call `node.set_attribute(...)` or similar on a mutable node, without ever realizing there is an atomic reference counter and a mutex behind the `Node` struct. In theory this enables parallel traversals / mutations such as the mock test added here, to the tune of:
```rust
use rayon::prelude::*;
// ...
nodes.into_par_iter().for_each(|mut node| {
   node.set_attribute("key","val");
}
```

and get the parallel processing for free via the rayon iterator, while still remaining safe for mutation thanks to the `Arc<Mutex<...>>`.

The two main bits that are worrying me are:

 1. This loses performance for single-threaded applications, and I assume most crate users will focus on exactly that classic application type. Maybe it makes sense to have a separate set of parallel structs, such as `NodeAtomic` and `DocumentAtomic`, which implement Send+Sync, instead of overriding the basic structs, so that single-threaded users are not impacted... but the boilerplate will become huge if I try to maintain two implementations...

2. Sanity. I am quite troubled that I had to manually "claim" the final structs are Sync+Send via:
```rust
#[derive(Clone, Debug)]
pub struct Node(NodeRef);

unsafe impl Sync for Node {}
unsafe impl Send for Node {}
```

I would sleep much better if Rust could auto-derive those, based on the `Arc<Mutex<...>>` that is now wrapping `NodeRef`, but I am unsure if I am missing a piece to achieve that, or if that is not even possible for custom structs... Feedback welcome.

P.S. The rayon test, and rayon dependency, are just here for purposes of example, I would remove both before merging any version of this PR, as I don't think rayon should be a dependency for the generic libxml crate.