### PR TITLE
Fix compiling on Mac OS X 10.14 (and presumably anywhere else that LIBXML_THREAD_ENABLED is set)

### DIFF
--- a/src/c_helpers.rs
+++ b/src/c_helpers.rs
@@ -95,7 +95,8 @@ pub fn xmlNodeGetName(cur: xmlNodePtr) -> *const c_char {
 
 pub fn setIndentTreeOutput(indent: c_int) {
   unsafe {
-    xmlIndentTreeOutput = indent;
+    let xml_indent_tree_output_ptr = __xmlIndentTreeOutput();
+    (*xml_indent_tree_output_ptr) = indent;
   }
 }
 


### PR DESCRIPTION
The problem is that `LIBXML_THREAD_ENABLED` changes the `xmlIndentTreeOutput` global from a simple global variable into a function call that returns an lvalue. The only proper way to detect and handle this is to just use the macro in C.

This patch adds c_wrappers.c and compiles it in the build.rs. I tested this with a recent nightly rust on Mac OS X 10.14 and Debian testing.