### PR TITLE
safely unlink xpath-obtained nodes

### DIFF
--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -753,6 +753,12 @@ impl Node {
   /// internal helper to ensure the node is marked as unlinked/removed from the main document tree
   fn set_unlinked(&mut self) {
     self.0.borrow_mut().unlinked = true;
+    self
+      .get_docref()
+      .upgrade()
+      .unwrap()
+      .borrow_mut()
+      .forget_node(self.node_ptr());
   }
 
   /// find nodes via xpath, at a specified node or the document root
@@ -778,17 +784,22 @@ impl Node {
           old.unlink();
           Ok(old)
         } else {
-          Err(From::from(
-            format!("Old node was not a child of {:?} parent. Registered parent is {:?} instead.", self.get_name(), old_parent.get_name())
-          ))
+          Err(From::from(format!(
+            "Old node was not a child of {:?} parent. Registered parent is {:?} instead.",
+            self.get_name(),
+            old_parent.get_name()
+          )))
         }
       } else {
-        Err(From::from(
-          format!("Old node was not a child of {:?} parent. No registered parent exists.", self.get_name())
-        ))
+        Err(From::from(format!(
+          "Old node was not a child of {:?} parent. No registered parent exists.",
+          self.get_name()
+        )))
       }
     } else {
-      Err(From::from("Can only call replace_child_node an a NodeType::Element type parent."))
+      Err(From::from(
+        "Can only call replace_child_node an a NodeType::Element type parent.",
+      ))
     }
   }
 }


### PR DESCRIPTION
Fixes #50 , thanks to @caldwell for the report!

Our memory management strategy is a bit too subtle, since the timing criteria can start getting hard to trace when we have all of nodes, document and xpath nodesets interplaying.

The goal remains simple: we bookkeep all nodes in our rust `_Document` object, and avoid freeing any node individually, as long as they are linked to an owner document - we free the entire document on drop, and the nodes get cleaned up along with it. For unlinked nodes, the idea so far has been that we can safely call `xmlFreeNode` when they drop out of scope in Rust, and have them cleaned up. But that relied on us figuring out the ownership and timing of all related structs, so that an unlinked node is really only explicitly freed once (i.e. it's really unlinked).

I admit I start getting lost in tracking the drop + free sequence, and would need some tooling to be really sure I know what is going on... 

The solution I propose ought to be safe & a general guard we could have included earlier -- when a node is marked as unlinked, it can be explicitly forgotten from the `nodes` map stored by its Document, ensuring that as soon as it goes out of scope in Rust, the drop+free combo will fire. Previously these nodes remained in Document until the doc itself went out of scope, typically at the end of the program, which causes additional headache in figuring out the drop order. By forgetting the node as soon as it is unlinked we get closer to safe Rust behavior, as far as I understand things.

The one bit I want to double-check tomorrow, before I merge this PR, is whether we are not accidentally leaking any memory now -- I will rerun the tests under valgrind to double-check.