### PR TITLE
Stricter memory management of new Nodes

### DIFF
--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -127,6 +127,7 @@ impl Document {
     unsafe {
       xmlDocSetRootElement(self.doc_ptr(), root.node_ptr());
     }
+    root.set_linked();
   }
 
   fn ptr_as_result(&mut self, node_ptr: xmlNodePtr) -> Result<Node, ()> {
@@ -152,6 +153,7 @@ impl Document {
       .forget_node(node.node_ptr());
 
     let node_ptr = unsafe { xmlDocCopyNode(node.node_ptr(), self.doc_ptr(), 1) };
+    node.set_linked();
     self.ptr_as_result(node_ptr)
   }
 


### PR DESCRIPTION
As a follow-up research on #51 , I got reminded that tree_tests were still leaking some memory, to be precise:
```
==69165== LEAK SUMMARY:
==69165==    definitely lost: 448 bytes in 4 blocks
==69165==    indirectly lost: 15 bytes in 3 blocks
==69165==      possibly lost: 0 bytes in 0 blocks
==69165==    still reachable: 1,094 bytes in 20 blocks
==69165==         suppressed: 0 bytes in 0 blocks
```

Some were caused by a problem I had commented on in `Node::get_namespaces`, that frankly I won't have time to address before it becomes critical in someone's application. But I felt particularly bad about nodes created via the various `new` methods in Rust leaking out, which one can trace to our `wrap` mechanism being incomplete.

New nodes are associated with a document, but not part of its tree unless they are set/inserted/imported via the various methods. That implies (... from my self-taught understanding...) that when a document is freed, and its tree is recursively freed in turn in libxml2, all nodes that are not inside the tree will not get freed - and hence leak out and show up in the valgrind report.

The solution seems to be to have a second form of wrap, `wrap_new`, which is explicit about the node being not-yet-linked. Also, it's good to ensure the various setters that extend the tree call `.set_linked` on the added Node.

All in all, tests continue to pass, and the tree_tests valgrind report from above is down to only the namespace-related entry, looking almost perfect:
```
==74718== LEAK SUMMARY:
==74718==    definitely lost: 88 bytes in 1 blocks
==74718==    indirectly lost: 0 bytes in 0 blocks
==74718==      possibly lost: 0 bytes in 0 blocks
==74718==    still reachable: 1,094 bytes in 20 blocks
==74718==         suppressed: 0 bytes in 0 blocks
```