### PR TITLE
RoNode: read-only parallelization with minimal overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Change Log
 
-## [0.2.10] (in active development)
+## [0.2.11] (in active development)
+
+## [0.2.10] 2019-14-04
+
+### Added
+
+ * `RoNode` primitive for simple and efficient **read-only** parallel processing
+ * Benchmarking a 120 MB XML document shows a twenty five fold speedup, when comparing `Node` to parallel rayon processing over `RoNode` with a 32 logical core desktop
+ * While `RoNode` is added as an experiment for high performance read-only scans, any mutability requires using `Node` and incurring a bookkeeping cost of safety at runtime.
+ * Introduced benchmarking via `criterion`, only installed during development.
+ * `benches/parsing_benchmarks` contains examples of parallel scanning via `rayon` iterators.
+ * added `Document::get_root_readonly` method for obtaining a `RoNode` root.
+ * added `Context::node_evaluate_readonly` method for searching over a `RoNode`
+ * added `Context::get_readonly_nodes_as_vec` method for collecting xpath results as `RoNode`
 
 ## [0.2.9] 2019-28-03
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libxml"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2018"
 authors = ["Andreas Franzén <andreas@devil.se>", "Deyan Ginev <deyan.ginev@gmail.com>","Jan Frederik Schaefer <j.schaefer@jacobs-university.de>"]
 description = "A Rust wrapper for libxml2 - the XML C parser and toolkit developed for the Gnome project"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,19 @@ exclude = [
   "scripts/*"
 ]
 
+[lib]
+name = "libxml"
+
 [dependencies]
 libc = "0.2"
 
 [build-dependencies]
 pkg-config = "0.3.2"
 
-[lib]
-name = "libxml"
+[dev-dependencies]
+rayon = "1.0.0"
+criterion = "0.2.10"
+
+[[bench]]
+name = "parsing_benchmarks"
+harness = false

--- a/benches/parsing_benchmarks.rs
+++ b/benches/parsing_benchmarks.rs
@@ -4,12 +4,20 @@ extern crate criterion;
 use criterion::Criterion;
 use libxml::parser::Parser;
 use libxml::readonly::RoNode;
-use libxml::tree::NodeType;
+use libxml::tree::{Node, NodeType};
 use rayon::prelude::*;
 
 // -- workhorse functions
 // not *quite* classic depth-first search, since we keep all children at the current level in memory,
 // but certainly DFS-order for traversal
+
+fn dfs_single_classic(node: Node) -> i32 {
+  1 + node
+    .get_child_nodes()
+    .into_iter()
+    .map(dfs_single_classic)
+    .sum::<i32>()
+}
 
 fn dfs_single(node: RoNode) -> i32 {
   1 + node
@@ -25,6 +33,18 @@ fn dfs_parallel(node: RoNode) -> i32 {
     .into_par_iter()
     .map(dfs_parallel)
     .sum::<i32>()
+}
+
+fn dfs_single_classic_work2(node: Node) -> (i32, usize) {
+  if node.get_type() == Some(NodeType::TextNode) {
+    (1, node.get_content().len())
+  } else {
+    node
+      .get_child_nodes()
+      .into_iter()
+      .map(dfs_single_classic_work2)
+      .fold((1, 0), |acc, x| (acc.0 + x.0, acc.1 + x.1))
+  }
 }
 
 fn dfs_single_work2(node: RoNode) -> (i32, usize) {
@@ -53,11 +73,35 @@ fn dfs_parallel_work2(node: RoNode) -> (i32, usize) {
 }
 
 // --- bencher functions
+// to get big.xml download, unpack and rename:
+// http://www.ins.cwi.nl/projects/xmark/Assets/standard.gz
+// or use your own XML sample
+fn bench_single_thread_classic(c: &mut Criterion) {
+  let parser = Parser::default();
+  let doc = parser.parse_file("benches/big.xml").unwrap();
+  c.bench_function("single thread DFS count", move |b| {
+    b.iter(|| {
+      let root = doc.get_root_element().unwrap();
+      assert_eq!(dfs_single_classic(root), 4_690_647)
+    })
+  });
+}
+
+fn bench_single_thread_classic_work2(c: &mut Criterion) {
+  let parser = Parser::default();
+  let doc = parser.parse_file("benches/big.xml").unwrap();
+  c.bench_function("single thread DFS count+length", move |b| {
+    b.iter(|| {
+      let root = doc.get_root_element().unwrap();
+      assert_eq!(dfs_single_classic_work2(root), (4_690_647, 81_286_567))
+    })
+  });
+}
 
 fn bench_single_thread(c: &mut Criterion) {
   let parser = Parser::default();
   let doc = parser.parse_file("benches/big.xml").unwrap();
-  c.bench_function("single thread DFS count", move |b| {
+  c.bench_function("read-only single thread DFS count", move |b| {
     b.iter(|| {
       let root = doc.get_root_readonly().unwrap();
       assert_eq!(dfs_single(root), 4_690_647)
@@ -68,7 +112,7 @@ fn bench_single_thread(c: &mut Criterion) {
 fn bench_single_thread_work2(c: &mut Criterion) {
   let parser = Parser::default();
   let doc = parser.parse_file("benches/big.xml").unwrap();
-  c.bench_function("single thread DFS count+length", move |b| {
+  c.bench_function("read-only single thread DFS count+length", move |b| {
     b.iter(|| {
       let root = doc.get_root_readonly().unwrap();
       assert_eq!(dfs_single_work2(root), (4_690_647, 81_286_567))
@@ -79,7 +123,7 @@ fn bench_single_thread_work2(c: &mut Criterion) {
 fn bench_multi_thread(c: &mut Criterion) {
   let parser = Parser::default();
   let doc = parser.parse_file("benches/big.xml").unwrap();
-  c.bench_function("multi thread DFS count", move |b| {
+  c.bench_function("read-only multi thread DFS count", move |b| {
     b.iter(|| {
       let root = doc.get_root_readonly().unwrap();
       assert_eq!(dfs_parallel(root), 4_690_647);
@@ -90,7 +134,7 @@ fn bench_multi_thread(c: &mut Criterion) {
 fn bench_multi_thread_work2(c: &mut Criterion) {
   let parser = Parser::default();
   let doc = parser.parse_file("benches/big.xml").unwrap();
-  c.bench_function("multi thread DFS count+length", move |b| {
+  c.bench_function("read-only multi thread DFS count+length", move |b| {
     b.iter(|| {
       let root = doc.get_root_readonly().unwrap();
       assert_eq!(dfs_parallel_work2(root), (4_690_647, 81_286_567))
@@ -100,7 +144,7 @@ fn bench_multi_thread_work2(c: &mut Criterion) {
 criterion_group!(
   name = benches;
   config = Criterion::default().sample_size(10);
-  targets = bench_single_thread, bench_single_thread_work2, bench_multi_thread, bench_multi_thread_work2
+  targets = bench_single_thread_classic,  bench_single_thread_classic_work2, bench_single_thread, bench_single_thread_work2, bench_multi_thread, bench_multi_thread_work2
 );
 
 criterion_main!(benches);

--- a/benches/parsing_benchmarks.rs
+++ b/benches/parsing_benchmarks.rs
@@ -1,0 +1,106 @@
+#[macro_use]
+extern crate criterion;
+
+use criterion::Criterion;
+use libxml::parser::Parser;
+use libxml::readonly::RoNode;
+use libxml::tree::NodeType;
+use rayon::prelude::*;
+
+// -- workhorse functions
+// not *quite* classic depth-first search, since we keep all children at the current level in memory,
+// but certainly DFS-order for traversal
+
+fn dfs_single(node: RoNode) -> i32 {
+  1 + node
+    .get_child_nodes()
+    .into_iter()
+    .map(dfs_single)
+    .sum::<i32>()
+}
+
+fn dfs_parallel(node: RoNode) -> i32 {
+  1 + node
+    .get_child_nodes()
+    .into_par_iter()
+    .map(dfs_parallel)
+    .sum::<i32>()
+}
+
+fn dfs_single_work2(node: RoNode) -> (i32, usize) {
+  if node.get_type() == Some(NodeType::TextNode) {
+    (1, node.get_content().len())
+  } else {
+    node
+      .get_child_nodes()
+      .into_iter()
+      .map(dfs_single_work2)
+      .fold((1, 0), |acc, x| (acc.0 + x.0, acc.1 + x.1))
+  }
+}
+
+fn dfs_parallel_work2(node: RoNode) -> (i32, usize) {
+  if node.get_type() == Some(NodeType::TextNode) {
+    (1, node.get_content().len())
+  } else {
+    let dfs_work = node
+      .get_child_nodes()
+      .into_par_iter()
+      .map(dfs_parallel_work2)
+      .reduce(|| (0, 0), |acc, x| (acc.0 + x.0, acc.1 + x.1));
+    (dfs_work.0 + 1, dfs_work.1)
+  }
+}
+
+// --- bencher functions
+
+fn bench_single_thread(c: &mut Criterion) {
+  let parser = Parser::default();
+  let doc = parser.parse_file("benches/big.xml").unwrap();
+  c.bench_function("single thread DFS count", move |b| {
+    b.iter(|| {
+      let root = doc.get_root_readonly().unwrap();
+      assert_eq!(dfs_single(root), 4_690_647)
+    })
+  });
+}
+
+fn bench_single_thread_work2(c: &mut Criterion) {
+  let parser = Parser::default();
+  let doc = parser.parse_file("benches/big.xml").unwrap();
+  c.bench_function("single thread DFS count+length", move |b| {
+    b.iter(|| {
+      let root = doc.get_root_readonly().unwrap();
+      assert_eq!(dfs_single_work2(root), (4_690_647, 81_286_567))
+    })
+  });
+}
+
+fn bench_multi_thread(c: &mut Criterion) {
+  let parser = Parser::default();
+  let doc = parser.parse_file("benches/big.xml").unwrap();
+  c.bench_function("multi thread DFS count", move |b| {
+    b.iter(|| {
+      let root = doc.get_root_readonly().unwrap();
+      assert_eq!(dfs_parallel(root), 4_690_647);
+    })
+  });
+}
+
+fn bench_multi_thread_work2(c: &mut Criterion) {
+  let parser = Parser::default();
+  let doc = parser.parse_file("benches/big.xml").unwrap();
+  c.bench_function("multi thread DFS count+length", move |b| {
+    b.iter(|| {
+      let root = doc.get_root_readonly().unwrap();
+      assert_eq!(dfs_parallel_work2(root), (4_690_647, 81_286_567))
+    })
+  });
+}
+criterion_group!(
+  name = benches;
+  config = Criterion::default().sample_size(10);
+  targets = bench_single_thread, bench_single_thread_work2, bench_multi_thread, bench_multi_thread_work2
+);
+
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,3 +16,6 @@ pub mod parser;
 pub mod tree;
 /// `XPath` module for global lookup in the DOM
 pub mod xpath;
+
+/// Read-only parallel primitives
+pub mod readonly;

--- a/src/readonly.rs
+++ b/src/readonly.rs
@@ -1,0 +1,3 @@
+mod tree;
+
+pub use self::tree::RoNode;

--- a/src/readonly/tree.rs
+++ b/src/readonly/tree.rs
@@ -1,0 +1,360 @@
+use libc::{c_char, c_void};
+use std::collections::{HashMap, HashSet};
+use std::ffi::{CStr, CString};
+use std::str;
+
+use crate::bindings::*;
+use crate::c_helpers::*;
+use crate::tree::namespace::Namespace;
+use crate::tree::nodetype::NodeType;
+use crate::tree::Document;
+use crate::xpath::Context;
+
+/// Lightweight struct for read-only parallel processing
+#[derive(Debug, Copy, Clone)]
+pub struct RoNode(pub(crate) xmlNodePtr);
+
+// we claim Sync and Send, as we are in read-only mode over the owning document
+unsafe impl Sync for RoNode {}
+unsafe impl Send for RoNode {}
+
+impl PartialEq for RoNode {
+  /// Two nodes are considered equal, if they point to the same xmlNode.
+  fn eq(&self, other: &RoNode) -> bool {
+    self.0 == other.0
+  }
+}
+impl Eq for RoNode {}
+
+impl RoNode {
+  /// Returns the next sibling if it exists
+  pub fn get_next_sibling(&self) -> Option<RoNode> {
+    let ptr = xmlNextSibling(self.0);
+    self.ptr_as_option(ptr)
+  }
+
+  /// Returns the previous sibling if it exists
+  pub fn get_prev_sibling(&self) -> Option<RoNode> {
+    let ptr = xmlPrevSibling(self.0);
+    self.ptr_as_option(ptr)
+  }
+
+  /// Returns the first child if it exists
+  pub fn get_first_child(&self) -> Option<RoNode> {
+    let ptr = xmlGetFirstChild(self.0);
+    self.ptr_as_option(ptr)
+  }
+
+  /// Returns the first element child if it exists
+  pub fn get_first_element_child(&self) -> Option<RoNode> {
+    match self.get_first_child() {
+      None => None,
+      Some(child) => {
+        let mut current_node = child;
+        while !current_node.is_element_node() {
+          if let Some(sibling) = current_node.get_next_sibling() {
+            current_node = sibling;
+          } else {
+            break;
+          }
+        }
+        if current_node.is_element_node() {
+          Some(current_node)
+        } else {
+          None
+        }
+      }
+    }
+  }
+
+  /// Returns the last child if it exists
+  pub fn get_last_child(&self) -> Option<RoNode> {
+    let ptr = unsafe { xmlGetLastChild(self.0) };
+    self.ptr_as_option(ptr)
+  }
+
+  /// Returns all child nodes of the given node as a vector
+  pub fn get_child_nodes(&self) -> Vec<RoNode> {
+    let mut children = Vec::new();
+    if let Some(first_child) = self.get_first_child() {
+      children.push(first_child);
+      while let Some(sibling) = children.last().unwrap().get_next_sibling() {
+        children.push(sibling)
+      }
+    }
+    children
+  }
+
+  /// Returns all child elements of the given node as a vector
+  pub fn get_child_elements(&self) -> Vec<RoNode> {
+    self
+      .get_child_nodes()
+      .into_iter()
+      .filter(|n| n.get_type() == Some(NodeType::ElementNode))
+      .collect::<Vec<RoNode>>()
+  }
+
+  /// Returns the parent if it exists
+  pub fn get_parent(&self) -> Option<RoNode> {
+    let ptr = xmlGetParent(self.0);
+    self.ptr_as_option(ptr)
+  }
+
+  /// Get the node type
+  pub fn get_type(&self) -> Option<NodeType> {
+    NodeType::from_int(xmlGetNodeType(self.0))
+  }
+
+  /// Returns true iff it is a text node
+  pub fn is_text_node(&self) -> bool {
+    self.get_type() == Some(NodeType::TextNode)
+  }
+
+  /// Checks if the given node is an Element
+  pub fn is_element_node(&self) -> bool {
+    self.get_type() == Some(NodeType::ElementNode)
+  }
+
+  /// Checks if the underlying libxml2 pointer is `NULL`
+  pub fn is_null(&self) -> bool {
+    self.0.is_null()
+  }
+
+  /// Returns the name of the node (empty string if name pointer is `NULL`)
+  pub fn get_name(&self) -> String {
+    let name_ptr = xmlNodeGetName(self.0);
+    if name_ptr.is_null() {
+      return String::new();
+    } //empty string
+    let c_string = unsafe { CStr::from_ptr(name_ptr) };
+    c_string.to_string_lossy().into_owned()
+  }
+
+  /// Returns the content of the node
+  /// (assumes UTF-8 XML document)
+  pub fn get_content(&self) -> String {
+    let content_ptr = unsafe { xmlNodeGetContent(self.0) };
+    if content_ptr.is_null() {
+      //empty string when none
+      return String::new();
+    }
+    let c_string = unsafe { CStr::from_ptr(content_ptr as *const c_char) };
+    let rust_utf8 = c_string.to_string_lossy().into_owned();
+    unsafe {
+      libc::free(content_ptr as *mut c_void);
+    }
+    rust_utf8
+  }
+
+  /// Returns the value of property `name`
+  pub fn get_property(&self, name: &str) -> Option<String> {
+    let c_name = CString::new(name).unwrap();
+    let value_ptr = unsafe { xmlGetProp(self.0, c_name.as_bytes().as_ptr()) };
+    if value_ptr.is_null() {
+      return None;
+    }
+    let c_value_string = unsafe { CStr::from_ptr(value_ptr as *const c_char) };
+    let prop_str = c_value_string.to_string_lossy().into_owned();
+    // A safe way to free the memory is using libc::free -- I have experienced that xmlFree from libxml2 is not reliable
+    unsafe {
+      libc::free(value_ptr as *mut c_void);
+    }
+    Some(prop_str)
+  }
+
+  /// Returns the value of property `name` in namespace `ns`
+  pub fn get_property_ns(&self, name: &str, ns: &str) -> Option<String> {
+    let c_name = CString::new(name).unwrap();
+    let c_ns = CString::new(ns).unwrap();
+    let value_ptr =
+      unsafe { xmlGetNsProp(self.0, c_name.as_bytes().as_ptr(), c_ns.as_bytes().as_ptr()) };
+    if value_ptr.is_null() {
+      return None;
+    }
+    let c_value_string = unsafe { CStr::from_ptr(value_ptr as *const c_char) };
+    let prop_str = c_value_string.to_string_lossy().into_owned();
+    unsafe {
+      libc::free(value_ptr as *mut c_void);
+    }
+    Some(prop_str)
+  }
+
+  /// Return an attribute as a `Node` struct of type AttributeNode
+  pub fn get_property_node(&self, name: &str) -> Option<RoNode> {
+    let c_name = CString::new(name).unwrap();
+    unsafe {
+      let attr_node = xmlHasProp(self.0, c_name.as_bytes().as_ptr());
+      self.ptr_as_option(attr_node as xmlNodePtr)
+    }
+  }
+
+  /// Alias for get_property
+  pub fn get_attribute(&self, name: &str) -> Option<String> {
+    self.get_property(name)
+  }
+  /// Alias for get_property_ns
+  pub fn get_attribute_ns(&self, name: &str, ns: &str) -> Option<String> {
+    self.get_property_ns(name, ns)
+  }
+
+  /// Alias for get_property_node
+  pub fn get_attribute_node(&self, name: &str) -> Option<RoNode> {
+    self.get_property_node(name)
+  }
+
+  /// Get a copy of the attributes of this node
+  pub fn get_properties(&self) -> HashMap<String, String> {
+    let mut attributes = HashMap::new();
+    let mut attr_names = Vec::new();
+    unsafe {
+      let mut current_prop = xmlGetFirstProperty(self.0);
+      while !current_prop.is_null() {
+        let name_ptr = xmlAttrName(current_prop);
+        let c_name_string = CStr::from_ptr(name_ptr);
+        let name = c_name_string.to_string_lossy().into_owned();
+        attr_names.push(name);
+        current_prop = xmlNextPropertySibling(current_prop);
+      }
+    }
+
+    for name in attr_names {
+      let value = self.get_property(&name).unwrap_or_default();
+      attributes.insert(name, value);
+    }
+
+    attributes
+  }
+
+  /// Alias for `get_properties`
+  pub fn get_attributes(&self) -> HashMap<String, String> {
+    self.get_properties()
+  }
+
+  /// Gets the active namespace associated of this node
+  pub fn get_namespace(&self) -> Option<Namespace> {
+    let ns_ptr = xmlNodeNs(self.0);
+    if ns_ptr.is_null() {
+      None
+    } else {
+      Some(Namespace { ns_ptr })
+    }
+  }
+
+  /// Gets a list of namespaces associated with this node
+  pub fn get_namespaces(&self, doc: &Document) -> Vec<Namespace> {
+    let list_ptr_raw = unsafe { xmlGetNsList(doc.doc_ptr(), self.0) };
+    if list_ptr_raw.is_null() {
+      Vec::new()
+    } else {
+      let mut namespaces = Vec::new();
+      let mut ptr_iter = list_ptr_raw as *mut xmlNsPtr;
+      unsafe {
+        while !ptr_iter.is_null() && !(*ptr_iter).is_null() {
+          namespaces.push(Namespace { ns_ptr: *ptr_iter });
+          ptr_iter = ptr_iter.add(1);
+        }
+        /* TODO: valgrind suggests this technique isn't sufficiently fluent:
+          ==114895== Conditional jump or move depends on uninitialised value(s)
+          ==114895==    at 0x4E9962F: xmlFreeNs (in /usr/lib/x86_64-linux-gnu/libxml2.so.2.9.4)
+          ==114895==    by 0x195CE8: libxml::tree::Node::get_namespaces (tree.rs:723)
+          ==114895==    by 0x12E7B6: base_tests::can_work_with_namespaces (base_tests.rs:537)
+          DG: I could not improve on this state without creating memory leaks after ~1 hour, so I am
+          marking it as future work.
+        */
+        /* TODO: How do we properly deallocate here? The approach bellow reliably segfaults tree_tests on 1 thread */
+        // println!("\n-- xmlfreens on : {:?}", list_ptr_raw);
+        // xmlFreeNs(list_ptr_raw as xmlNsPtr);
+      }
+      namespaces
+    }
+  }
+
+  /// Get a list of namespaces declared with this node
+  pub fn get_namespace_declarations(&self) -> Vec<Namespace> {
+    if self.get_type() != Some(NodeType::ElementNode) {
+      // only element nodes can have declarations
+      return Vec::new();
+    }
+    let mut namespaces = Vec::new();
+    let mut ns_ptr = xmlNodeNsDeclarations(self.0);
+    while !ns_ptr.is_null() {
+      if !xmlNsPrefix(ns_ptr).is_null() || !xmlNsHref(ns_ptr).is_null() {
+        namespaces.push(Namespace { ns_ptr });
+      }
+      ns_ptr = xmlNextNsSibling(ns_ptr);
+    }
+    namespaces
+  }
+
+  /// Looks up the prefix of a namespace from its URI, basedo around a given `Node`
+  pub fn lookup_namespace_prefix(&self, href: &str) -> Option<String> {
+    if href.is_empty() {
+      return None;
+    }
+    let c_href = CString::new(href).unwrap();
+    unsafe {
+      let ptr_mut = self.0;
+      let ns_ptr = xmlSearchNsByHref(xmlGetDoc(ptr_mut), ptr_mut, c_href.as_bytes().as_ptr());
+      if !ns_ptr.is_null() {
+        let ns = Namespace { ns_ptr };
+        let ns_prefix = ns.get_prefix();
+        Some(ns_prefix)
+      } else {
+        None
+      }
+    }
+  }
+
+  /// Looks up the uri of a namespace from its prefix, basedo around a given `Node`
+  pub fn lookup_namespace_uri(&self, prefix: &str) -> Option<String> {
+    if prefix.is_empty() {
+      return None;
+    }
+    let c_prefix = CString::new(prefix).unwrap();
+    unsafe {
+      let ns_ptr = xmlSearchNs(xmlGetDoc(self.0), self.0, c_prefix.as_bytes().as_ptr());
+      if !ns_ptr.is_null() {
+        let ns = Namespace { ns_ptr };
+        let ns_prefix = ns.get_href();
+        if !ns_prefix.is_empty() {
+          Some(ns_prefix)
+        } else {
+          None
+        }
+      } else {
+        None
+      }
+    }
+  }
+
+  /// Get a set of class names from this node's attributes
+  pub fn get_class_names(&self) -> HashSet<String> {
+    let mut set = HashSet::new();
+    if let Some(value) = self.get_property("class") {
+      for n in value.split(' ') {
+        set.insert(n.to_owned());
+      }
+    }
+    set
+  }
+
+  /// find read-only nodes via xpath, at the specified node and a given document
+  pub fn findnodes(&self, xpath: &str, owner: &Document) -> Result<Vec<RoNode>, ()> {
+    let context = Context::new(owner)?;
+    let evaluated = context.node_evaluate_ro(xpath, self)?;
+    Ok(evaluated.get_readonly_nodes_as_vec())
+  }
+
+  /// Read-only nodes are always linked
+  pub fn is_unlinked(&self) -> bool {
+    false
+  }
+  /// Read-only nodes only need a null check
+  fn ptr_as_option(&self, node_ptr: xmlNodePtr) -> Option<RoNode> {
+    if node_ptr.is_null() {
+      None
+    } else {
+      Some(RoNode(node_ptr))
+    }
+  }
+}

--- a/src/readonly/tree.rs
+++ b/src/readonly/tree.rs
@@ -341,7 +341,7 @@ impl RoNode {
   /// find read-only nodes via xpath, at the specified node and a given document
   pub fn findnodes(&self, xpath: &str, owner: &Document) -> Result<Vec<RoNode>, ()> {
     let context = Context::new(owner)?;
-    let evaluated = context.node_evaluate_ro(xpath, self)?;
+    let evaluated = context.node_evaluate_readonly(xpath, self)?;
     Ok(evaluated.get_readonly_nodes_as_vec())
   }
 

--- a/src/readonly/tree.rs
+++ b/src/readonly/tree.rs
@@ -28,25 +28,25 @@ impl Eq for RoNode {}
 
 impl RoNode {
   /// Returns the next sibling if it exists
-  pub fn get_next_sibling(&self) -> Option<RoNode> {
+  pub fn get_next_sibling(self) -> Option<RoNode> {
     let ptr = xmlNextSibling(self.0);
     self.ptr_as_option(ptr)
   }
 
   /// Returns the previous sibling if it exists
-  pub fn get_prev_sibling(&self) -> Option<RoNode> {
+  pub fn get_prev_sibling(self) -> Option<RoNode> {
     let ptr = xmlPrevSibling(self.0);
     self.ptr_as_option(ptr)
   }
 
   /// Returns the first child if it exists
-  pub fn get_first_child(&self) -> Option<RoNode> {
+  pub fn get_first_child(self) -> Option<RoNode> {
     let ptr = xmlGetFirstChild(self.0);
     self.ptr_as_option(ptr)
   }
 
   /// Returns the first element child if it exists
-  pub fn get_first_element_child(&self) -> Option<RoNode> {
+  pub fn get_first_element_child(self) -> Option<RoNode> {
     match self.get_first_child() {
       None => None,
       Some(child) => {
@@ -68,13 +68,13 @@ impl RoNode {
   }
 
   /// Returns the last child if it exists
-  pub fn get_last_child(&self) -> Option<RoNode> {
+  pub fn get_last_child(self) -> Option<RoNode> {
     let ptr = unsafe { xmlGetLastChild(self.0) };
     self.ptr_as_option(ptr)
   }
 
   /// Returns all child nodes of the given node as a vector
-  pub fn get_child_nodes(&self) -> Vec<RoNode> {
+  pub fn get_child_nodes(self) -> Vec<RoNode> {
     let mut children = Vec::new();
     if let Some(first_child) = self.get_first_child() {
       children.push(first_child);
@@ -86,7 +86,7 @@ impl RoNode {
   }
 
   /// Returns all child elements of the given node as a vector
-  pub fn get_child_elements(&self) -> Vec<RoNode> {
+  pub fn get_child_elements(self) -> Vec<RoNode> {
     self
       .get_child_nodes()
       .into_iter()
@@ -95,33 +95,33 @@ impl RoNode {
   }
 
   /// Returns the parent if it exists
-  pub fn get_parent(&self) -> Option<RoNode> {
+  pub fn get_parent(self) -> Option<RoNode> {
     let ptr = xmlGetParent(self.0);
     self.ptr_as_option(ptr)
   }
 
   /// Get the node type
-  pub fn get_type(&self) -> Option<NodeType> {
+  pub fn get_type(self) -> Option<NodeType> {
     NodeType::from_int(xmlGetNodeType(self.0))
   }
 
   /// Returns true iff it is a text node
-  pub fn is_text_node(&self) -> bool {
+  pub fn is_text_node(self) -> bool {
     self.get_type() == Some(NodeType::TextNode)
   }
 
   /// Checks if the given node is an Element
-  pub fn is_element_node(&self) -> bool {
+  pub fn is_element_node(self) -> bool {
     self.get_type() == Some(NodeType::ElementNode)
   }
 
   /// Checks if the underlying libxml2 pointer is `NULL`
-  pub fn is_null(&self) -> bool {
+  pub fn is_null(self) -> bool {
     self.0.is_null()
   }
 
   /// Returns the name of the node (empty string if name pointer is `NULL`)
-  pub fn get_name(&self) -> String {
+  pub fn get_name(self) -> String {
     let name_ptr = xmlNodeGetName(self.0);
     if name_ptr.is_null() {
       return String::new();
@@ -132,7 +132,7 @@ impl RoNode {
 
   /// Returns the content of the node
   /// (assumes UTF-8 XML document)
-  pub fn get_content(&self) -> String {
+  pub fn get_content(self) -> String {
     let content_ptr = unsafe { xmlNodeGetContent(self.0) };
     if content_ptr.is_null() {
       //empty string when none
@@ -147,7 +147,7 @@ impl RoNode {
   }
 
   /// Returns the value of property `name`
-  pub fn get_property(&self, name: &str) -> Option<String> {
+  pub fn get_property(self, name: &str) -> Option<String> {
     let c_name = CString::new(name).unwrap();
     let value_ptr = unsafe { xmlGetProp(self.0, c_name.as_bytes().as_ptr()) };
     if value_ptr.is_null() {
@@ -163,7 +163,7 @@ impl RoNode {
   }
 
   /// Returns the value of property `name` in namespace `ns`
-  pub fn get_property_ns(&self, name: &str, ns: &str) -> Option<String> {
+  pub fn get_property_ns(self, name: &str, ns: &str) -> Option<String> {
     let c_name = CString::new(name).unwrap();
     let c_ns = CString::new(ns).unwrap();
     let value_ptr =
@@ -180,7 +180,7 @@ impl RoNode {
   }
 
   /// Return an attribute as a `Node` struct of type AttributeNode
-  pub fn get_property_node(&self, name: &str) -> Option<RoNode> {
+  pub fn get_property_node(self, name: &str) -> Option<RoNode> {
     let c_name = CString::new(name).unwrap();
     unsafe {
       let attr_node = xmlHasProp(self.0, c_name.as_bytes().as_ptr());
@@ -189,21 +189,21 @@ impl RoNode {
   }
 
   /// Alias for get_property
-  pub fn get_attribute(&self, name: &str) -> Option<String> {
+  pub fn get_attribute(self, name: &str) -> Option<String> {
     self.get_property(name)
   }
   /// Alias for get_property_ns
-  pub fn get_attribute_ns(&self, name: &str, ns: &str) -> Option<String> {
+  pub fn get_attribute_ns(self, name: &str, ns: &str) -> Option<String> {
     self.get_property_ns(name, ns)
   }
 
   /// Alias for get_property_node
-  pub fn get_attribute_node(&self, name: &str) -> Option<RoNode> {
+  pub fn get_attribute_node(self, name: &str) -> Option<RoNode> {
     self.get_property_node(name)
   }
 
   /// Get a copy of the attributes of this node
-  pub fn get_properties(&self) -> HashMap<String, String> {
+  pub fn get_properties(self) -> HashMap<String, String> {
     let mut attributes = HashMap::new();
     let mut attr_names = Vec::new();
     unsafe {
@@ -226,12 +226,12 @@ impl RoNode {
   }
 
   /// Alias for `get_properties`
-  pub fn get_attributes(&self) -> HashMap<String, String> {
+  pub fn get_attributes(self) -> HashMap<String, String> {
     self.get_properties()
   }
 
   /// Gets the active namespace associated of this node
-  pub fn get_namespace(&self) -> Option<Namespace> {
+  pub fn get_namespace(self) -> Option<Namespace> {
     let ns_ptr = xmlNodeNs(self.0);
     if ns_ptr.is_null() {
       None
@@ -241,7 +241,7 @@ impl RoNode {
   }
 
   /// Gets a list of namespaces associated with this node
-  pub fn get_namespaces(&self, doc: &Document) -> Vec<Namespace> {
+  pub fn get_namespaces(self, doc: &Document) -> Vec<Namespace> {
     let list_ptr_raw = unsafe { xmlGetNsList(doc.doc_ptr(), self.0) };
     if list_ptr_raw.is_null() {
       Vec::new()
@@ -270,7 +270,7 @@ impl RoNode {
   }
 
   /// Get a list of namespaces declared with this node
-  pub fn get_namespace_declarations(&self) -> Vec<Namespace> {
+  pub fn get_namespace_declarations(self) -> Vec<Namespace> {
     if self.get_type() != Some(NodeType::ElementNode) {
       // only element nodes can have declarations
       return Vec::new();
@@ -287,7 +287,7 @@ impl RoNode {
   }
 
   /// Looks up the prefix of a namespace from its URI, basedo around a given `Node`
-  pub fn lookup_namespace_prefix(&self, href: &str) -> Option<String> {
+  pub fn lookup_namespace_prefix(self, href: &str) -> Option<String> {
     if href.is_empty() {
       return None;
     }
@@ -306,7 +306,7 @@ impl RoNode {
   }
 
   /// Looks up the uri of a namespace from its prefix, basedo around a given `Node`
-  pub fn lookup_namespace_uri(&self, prefix: &str) -> Option<String> {
+  pub fn lookup_namespace_uri(self, prefix: &str) -> Option<String> {
     if prefix.is_empty() {
       return None;
     }
@@ -328,7 +328,7 @@ impl RoNode {
   }
 
   /// Get a set of class names from this node's attributes
-  pub fn get_class_names(&self) -> HashSet<String> {
+  pub fn get_class_names(self) -> HashSet<String> {
     let mut set = HashSet::new();
     if let Some(value) = self.get_property("class") {
       for n in value.split(' ') {
@@ -339,18 +339,18 @@ impl RoNode {
   }
 
   /// find read-only nodes via xpath, at the specified node and a given document
-  pub fn findnodes(&self, xpath: &str, owner: &Document) -> Result<Vec<RoNode>, ()> {
+  pub fn findnodes(self, xpath: &str, owner: &Document) -> Result<Vec<RoNode>, ()> {
     let context = Context::new(owner)?;
     let evaluated = context.node_evaluate_readonly(xpath, self)?;
     Ok(evaluated.get_readonly_nodes_as_vec())
   }
 
   /// Read-only nodes are always linked
-  pub fn is_unlinked(&self) -> bool {
+  pub fn is_unlinked(self) -> bool {
     false
   }
   /// Read-only nodes only need a null check
-  fn ptr_as_option(&self, node_ptr: xmlNodePtr) -> Option<RoNode> {
+  fn ptr_as_option(self, node_ptr: xmlNodePtr) -> Option<RoNode> {
     if node_ptr.is_null() {
       None
     } else {

--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -12,6 +12,7 @@ use std::str;
 
 use crate::bindings::*;
 use crate::c_helpers::*;
+use crate::readonly::RoNode;
 use crate::tree::node::Node;
 
 pub(crate) type DocumentRef = Rc<RefCell<_Document>>;
@@ -118,6 +119,18 @@ impl Document {
         None
       } else {
         Some(self.register_node(node_ptr))
+      }
+    }
+  }
+
+  /// Get the root element of the document (read-only)
+  pub fn get_root_readonly(&self) -> Option<RoNode> {
+    unsafe {
+      let node_ptr = xmlDocGetRootElement(self.doc_ptr());
+      if node_ptr.is_null() {
+        None
+      } else {
+        Some(RoNode(node_ptr))
       }
     }
   }

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -127,7 +127,7 @@ impl Context {
   }
 
   ///evaluate an xpath on a context RoNode
-  pub fn node_evaluate_readonly(&self, xpath: &str, node: &RoNode) -> Result<Object, ()> {
+  pub fn node_evaluate_readonly(&self, xpath: &str, node: RoNode) -> Result<Object, ()> {
     let c_xpath = CString::new(xpath).unwrap();
     let ptr = unsafe { xmlXPathNodeEval(node.0, c_xpath.as_bytes().as_ptr(), self.as_ptr()) };
     if ptr.is_null() {

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -127,7 +127,7 @@ impl Context {
   }
 
   ///evaluate an xpath on a context RoNode
-  pub fn node_evaluate_ro(&self, xpath: &str, node: &RoNode) -> Result<Object, ()> {
+  pub fn node_evaluate_readonly(&self, xpath: &str, node: &RoNode) -> Result<Object, ()> {
     let c_xpath = CString::new(xpath).unwrap();
     let ptr = unsafe { xmlXPathNodeEval(node.0, c_xpath.as_bytes().as_ptr(), self.as_ptr()) };
     if ptr.is_null() {

--- a/tests/readonly_tests.rs
+++ b/tests/readonly_tests.rs
@@ -1,0 +1,56 @@
+//! Tree module tests
+//!
+use libxml::parser::Parser;
+use libxml::tree::NodeType;
+use libxml::readonly::RoNode;
+
+fn dfs_node(node: RoNode) -> i32 {
+  1 + node
+    .get_child_nodes()
+    .into_iter()
+    .map(dfs_node)
+    .sum::<i32>()
+}
+
+fn dfs_element(node: RoNode) -> i32 {
+  1 + node
+    .get_child_elements()
+    .into_iter()
+    .map(dfs_element)
+    .sum::<i32>()
+}
+
+
+#[test]
+fn readonly_scan_test() {
+  let parser = Parser::default_html();
+  let doc_result = parser.parse_file("tests/resources/example.html");
+  assert!(doc_result.is_ok());
+  let doc = doc_result.unwrap();
+
+  let root : RoNode = doc.get_root_readonly().unwrap();
+  assert_eq!(root.get_name(), "html");
+  // "get_child_nodes" exhaustivity test,
+  // 33 nodes, including text, comments, etc
+  assert_eq!(dfs_node(root), 33);
+  // "get_element_nodes" exhaustivity test,
+  // 13 named element nodes in example.html
+  assert_eq!(dfs_element(root), 13);
+
+  let text: RoNode = root.get_first_child().expect("first child is a text node");
+  assert_eq!(text.get_name(), "text");
+
+  let head : RoNode = root.get_first_element_child().expect("head is first child of html");
+  assert_eq!(head.get_name(), "head");
+
+  let mut sibling : RoNode = head.get_next_sibling().expect("head should be followed by text");
+  assert_eq!(sibling.get_name(), "text");
+  while let Some(next) = sibling.get_next_sibling() {
+    sibling = next;
+    if next.get_type() == Some(NodeType::ElementNode) {
+      break;
+    }
+  }
+  assert_eq!(sibling.get_type(), Some(NodeType::ElementNode));
+  assert_eq!(sibling.get_name(), "body");
+}


### PR DESCRIPTION
A simple and pragmatic take on a multi-threaded primitive (see #47 ). 

A benchmark on a huge 112 MB XML file with this PR reveals:
```
single thread DFS count
  time:   [1.1032 s 1.1079 s 1.1120 s]                                     

single thread DFS count+length
  time:   [1.3465 s 1.3498 s 1.3532 s]

read-only single thread DFS count
  time:   [302.88 ms 303.53 ms 304.31 ms]

read-only single thread DFS count+length
  time:   [534.57 ms 535.03 ms 535.71 ms]

read-only multi thread DFS count
  time:   [33.617 ms 34.120 ms 34.625 ms]

read-only multi thread DFS count+length
  time:   [51.574 ms 52.269 ms 52.765 ms]

```

Where the single thread uses the Node implementation of master, while the `read-only` and multi thread benchmarks use the new `RoNode` construct.

The pragmatics of the PR were:
 * only solve parallel processing for one use case (= my current need), which keeps it simple and easy to understand
 * only pay for features you use mantra -- my use case is entirely one of "scanning" an existing document, so *no* mutation, *no* bookkeeping, *no* data races. 
 * As libxml eagerly loads the entire document in memory, it is safe to have concurrent read operations executing on the tree.
 * The PR is a conservative extension over master, which is unchanged, it only adds a new `RoNode` primitive and related logic for using it.
 * `RoNode` is just `Node` with all mutation and bookkeeping removed, including related methods. A bit of boilerplate overload to copy-paste it all, one could imagine it becoming a `NodeReader` trait instead.

As you can see from the sample benchmark, on a huge file with a very minimal compute job you get a 10x speedup when running using rayon parallel iterators on my 32 logical thread CPU.