### PR TITLE
bindgen generation wrapper for cli use

### DIFF
--- a/scripts/bindgen_wrapper.h
+++ b/scripts/bindgen_wrapper.h
@@ -1,0 +1,53 @@
+/* Ensure you have libxml2 development headers installed first.
+   e.g. package libxml2-dev for Ubuntu
+
+Then run via:
+$ cargo install bindgen
+$ bindgen scripts/bindgen_wrapper.h -o src/bindings.rs -- `xml2-config --cflags`
+*/
+#include <libxml/HTMLparser.h>
+#include <libxml/HTMLtree.h>
+#include <libxml/SAX.h>
+#include <libxml/SAX2.h>
+#include <libxml/c14n.h>
+#include <libxml/catalog.h>
+#include <libxml/chvalid.h>
+#include <libxml/debugXML.h>
+#include <libxml/dict.h>
+#include <libxml/encoding.h>
+#include <libxml/entities.h>
+#include <libxml/globals.h>
+#include <libxml/hash.h>
+#include <libxml/list.h>
+#include <libxml/nanoftp.h>
+#include <libxml/nanohttp.h>
+#include <libxml/parser.h>
+#include <libxml/parserInternals.h>
+#include <libxml/pattern.h>
+#include <libxml/relaxng.h>
+#include <libxml/schemasInternals.h>
+#include <libxml/schematron.h>
+#include <libxml/threads.h>
+#include <libxml/tree.h>
+#include <libxml/uri.h>
+#include <libxml/valid.h>
+#include <libxml/xinclude.h>
+#include <libxml/xlink.h>
+#include <libxml/xmlIO.h>
+#include <libxml/xmlautomata.h>
+#include <libxml/xmlerror.h>
+#include <libxml/xmlexports.h>
+#include <libxml/xmlmemory.h>
+#include <libxml/xmlmodule.h>
+#include <libxml/xmlreader.h>
+#include <libxml/xmlregexp.h>
+#include <libxml/xmlsave.h>
+#include <libxml/xmlschemas.h>
+#include <libxml/xmlschemastypes.h>
+#include <libxml/xmlstring.h>
+#include <libxml/xmlunicode.h>
+#include <libxml/xmlversion.h>
+#include <libxml/xmlwriter.h>
+#include <libxml/xpath.h>
+#include <libxml/xpathInternals.h>
+#include <libxml/xpointer.h>

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,6 +5,7 @@ use crate::c_helpers::*;
 use crate::tree::*;
 
 use std::convert::AsRef;
+use std::error::Error;
 use std::ffi::c_void;
 use std::ffi::{CStr, CString};
 use std::fmt;
@@ -50,6 +51,8 @@ pub enum XmlParseError {
   ///Document too large for libxml2.
   DocumentTooLarge,
 }
+
+impl Error for XmlParseError {}
 
 impl fmt::Debug for XmlParseError
 {


### PR DESCRIPTION
Bundles in a script that allows for directly regenerating `src/bindings.rs` via:
```
bindgen scripts/bindgen_wrapper.h -o src/bindings.rs -- `xml2-config --cflags`
```

Some steps towards #73 