### PR TITLE
Add ParserOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [0.2.18] (in development)
 
+* Change `Parser::parse_file/string_with_encoding` to `Parser::parse_file/string_with_options`. Introduce `ParserOptions` which encapsulates the forced encoding setting together with libxml2s HTML and XML parser options.
+
 ## [0.2.17] 2021-17-05
 
 ### Added

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -77,16 +77,14 @@ impl<'a> ParserOptions<'a> {
       (
         $condition:expr => $variant:ident
       ) => {
-          {
-            if $condition {
-              match format {
-                ParseFormat::HTML => HtmlParserOption::$variant as i32,
-                ParseFormat::XML => XmlParserOption::$variant as i32,
-              }
-            } else {
-              0
-            }
+        if $condition {
+          match format {
+            ParseFormat::HTML => HtmlParserOption::$variant as i32,
+            ParseFormat::XML => XmlParserOption::$variant as i32,
           }
+        } else {
+          0
+        }
       };
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -233,7 +233,7 @@ impl Parser {
 
   /// Parses the XML/HTML file `filename` to generate a new `Document`
   pub fn parse_file(&self, filename: &str) -> Result<Document, XmlParseError> {
-    self.parse_file_with_options(filename, &ParserOptions::default())
+    self.parse_file_with_options(filename, ParserOptions::default())
   }
 
   /// Parses the XML/HTML file `filename` with a manually-specified parser-options
@@ -241,7 +241,7 @@ impl Parser {
   pub fn parse_file_with_options(
     &self,
     filename: &str,
-    parser_options: &ParserOptions,
+    parser_options: ParserOptions,
   ) -> Result<Document, XmlParseError> {
     // Create extern C callbacks for to read and close a Rust file through
     // a void pointer.
@@ -294,7 +294,7 @@ impl Parser {
 
   ///Parses the XML/HTML bytes `input` to generate a new `Document`
   pub fn parse_string<Bytes: AsRef<[u8]>>(&self, input: Bytes) -> Result<Document, XmlParseError> {
-    self.parse_string_with_options(input, &ParserOptions::default())
+    self.parse_string_with_options(input, ParserOptions::default())
   }
 
   ///Parses the XML/HTML bytes `input` with a manually-specified
@@ -302,7 +302,7 @@ impl Parser {
   pub fn parse_string_with_options<Bytes: AsRef<[u8]>>(
     &self,
     input: Bytes,
-    parser_options: &ParserOptions,
+    parser_options: ParserOptions,
   ) -> Result<Document, XmlParseError> {
     // Process input bytes.
     let input_bytes = input.as_ref();

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -3,7 +3,7 @@
 use std::fs::File;
 use std::io::Read;
 
-use libxml::parser::Parser;
+use libxml::parser::{Parser, ParserOptions};
 use libxml::tree::{Document, Node, SaveOptions};
 
 #[test]
@@ -164,6 +164,20 @@ fn well_formed_html() {
 
   let should_well_formed = parser.is_well_formed_html("<!DOCTYPE html>\n<html><head><title>Test</title></head><body>\n<h1>Tiny</h1><math><mn>2</mn></math></body></html>");
   assert!(should_well_formed);
+}
+
+#[test]
+/// Parse & serialize HTML fragment
+fn html_fragment() {
+  let fragment = r#"<figure><a href="tar-flac-subset-compress.svg"><img src="tar-flac-subset-compress.svg" alt="Compression results on incompressible data."></a><figcaption><p>Compression results on incompressible data.</p></figcaption></figure>"#;
+
+  let parser = Parser::default_html();
+  let document = parser.parse_string_with_options(&fragment, &ParserOptions { no_def_dtd: true, no_implied: true, ..Default::default()}).unwrap();
+
+  let mut serialized_fragment = document.to_string_with_options(SaveOptions { no_empty_tags: true, as_html: true, ..Default::default() });
+  let _added_newline = serialized_fragment.pop(); // remove added '\n'
+  
+  assert_eq!(fragment, serialized_fragment);
 }
 
 fn serialization_roundtrip(file_name: &str) {

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -172,11 +172,11 @@ fn html_fragment() {
   let fragment = r#"<figure><a href="tar-flac-subset-compress.svg"><img src="tar-flac-subset-compress.svg" alt="Compression results on incompressible data."></a><figcaption><p>Compression results on incompressible data.</p></figcaption></figure>"#;
 
   let parser = Parser::default_html();
-  let document = parser.parse_string_with_options(&fragment, &ParserOptions { no_def_dtd: true, no_implied: true, ..Default::default()}).unwrap();
+  let document = parser.parse_string_with_options(&fragment, ParserOptions { no_def_dtd: true, no_implied: true, ..Default::default()}).unwrap();
 
   let mut serialized_fragment = document.to_string_with_options(SaveOptions { no_empty_tags: true, as_html: true, ..Default::default() });
   let _added_newline = serialized_fragment.pop(); // remove added '\n'
-  
+
   assert_eq!(fragment, serialized_fragment);
 }
 


### PR DESCRIPTION
Fixes #85

To avoid too many `parse_file_with_` variants I included the encoding into the `ParserOptions`. Hope that is acceptable.