### PR TITLE
fix typos in docs

### DIFF
--- a/src/readonly/tree.rs
+++ b/src/readonly/tree.rs
@@ -178,7 +178,7 @@ impl RoNode {
     NodeType::from_int(xmlGetNodeType(self.0))
   }
 
-  /// Returns true iff it is a text node
+  /// Returns true if it is a text node
   pub fn is_text_node(self) -> bool {
     self.get_type() == Some(NodeType::TextNode)
   }

--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -256,7 +256,7 @@ impl Document {
     }
   }
 
-  /// Serializes a `Node` owned by this `Document
+  /// Serializes a `Node` owned by this `Document`
   pub fn node_to_string(&self, node: &Node) -> String {
     unsafe {
       // allocate a buffer to dump into
@@ -278,7 +278,7 @@ impl Document {
       node_string
     }
   }
-  /// Serializes a `RoNode` owned by this `Document
+  /// Serializes a `RoNode` owned by this `Document`
   pub fn ronode_to_string(&self, node: &RoNode) -> String {
     unsafe {
       // allocate a buffer to dump into

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -358,7 +358,7 @@ impl Node {
     }
   }
 
-  /// Returns true iff it is a text node
+  /// Returns true if it is a text node
   pub fn is_text_node(&self) -> bool {
     self.get_type() == Some(NodeType::TextNode)
   }


### PR DESCRIPTION
Thank you for creating and continuing to maintain this brilliant crate! It is the only solution that allows me to seemlessly translate my `lxml`-dependent Python code, with a significant usage of XPath (on HTML), into Rust (I have no idea why it is less popular than the other buggy and functionally incomplete crates; although porting from C is less exciting than writing in pure Rust, I think being able to work robustly is more important).

I'm currently not familiar with C (and its porting to Rust) , but I'm learning. I look forward to contributing to the source code when I become competent in the future. For now, what I can do is to fix some typos in the docs and provide any bug reports.