### PR TITLE
Remove tests using null pointer deref

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -614,16 +614,16 @@ fn bindgen_test_layout___fsid_t() {
     4usize,
     concat!("Alignment of ", stringify!(__fsid_t))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<__fsid_t>())).__val as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(__fsid_t),
-      "::",
-      stringify!(__val)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<__fsid_t>())).__val as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(__fsid_t),
+  //     "::",
+  //     stringify!(__val)
+  //   )
+  // );
 }
 pub type __clock_t = ::std::os::raw::c_long;
 pub type __rlim_t = ::std::os::raw::c_ulong;
@@ -679,26 +679,26 @@ fn bindgen_test_layout___mbstate_t__bindgen_ty_1() {
     4usize,
     concat!("Alignment of ", stringify!(__mbstate_t__bindgen_ty_1))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<__mbstate_t__bindgen_ty_1>())).__wch as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(__mbstate_t__bindgen_ty_1),
-      "::",
-      stringify!(__wch)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<__mbstate_t__bindgen_ty_1>())).__wchb as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(__mbstate_t__bindgen_ty_1),
-      "::",
-      stringify!(__wchb)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<__mbstate_t__bindgen_ty_1>())).__wch as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(__mbstate_t__bindgen_ty_1),
+  //     "::",
+  //     stringify!(__wch)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<__mbstate_t__bindgen_ty_1>())).__wchb as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(__mbstate_t__bindgen_ty_1),
+  //     "::",
+  //     stringify!(__wchb)
+  //   )
+  // );
 }
 #[test]
 fn bindgen_test_layout___mbstate_t() {
@@ -712,26 +712,26 @@ fn bindgen_test_layout___mbstate_t() {
     4usize,
     concat!("Alignment of ", stringify!(__mbstate_t))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<__mbstate_t>())).__count as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(__mbstate_t),
-      "::",
-      stringify!(__count)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<__mbstate_t>())).__value as *const _ as usize },
-    4usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(__mbstate_t),
-      "::",
-      stringify!(__value)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<__mbstate_t>())).__count as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(__mbstate_t),
+  //     "::",
+  //     stringify!(__count)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<__mbstate_t>())).__value as *const _ as usize },
+  //   4usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(__mbstate_t),
+  //     "::",
+  //     stringify!(__value)
+  //   )
+  // );
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -772,36 +772,36 @@ fn bindgen_test_layout__IO_marker() {
     8usize,
     concat!("Alignment of ", stringify!(_IO_marker))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_IO_marker>()))._next as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_IO_marker),
-      "::",
-      stringify!(_next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_IO_marker>()))._sbuf as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_IO_marker),
-      "::",
-      stringify!(_sbuf)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_IO_marker>()))._pos as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_IO_marker),
-      "::",
-      stringify!(_pos)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_IO_marker>()))._next as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_IO_marker),
+  //     "::",
+  //     stringify!(_next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_IO_marker>()))._sbuf as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_IO_marker),
+  //     "::",
+  //     stringify!(_sbuf)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_IO_marker>()))._pos as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_IO_marker),
+  //     "::",
+  //     stringify!(_pos)
+  //   )
+  // );
 }
 pub const __codecvt_result___codecvt_ok: __codecvt_result = 0;
 pub const __codecvt_result___codecvt_partial: __codecvt_result = 1;
@@ -1593,56 +1593,56 @@ fn bindgen_test_layout__xmlBuffer() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlBuffer))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlBuffer>())).content as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlBuffer),
-      "::",
-      stringify!(content)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlBuffer>())).use_ as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlBuffer),
-      "::",
-      stringify!(use_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlBuffer>())).size as *const _ as usize },
-    12usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlBuffer),
-      "::",
-      stringify!(size)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlBuffer>())).alloc as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlBuffer),
-      "::",
-      stringify!(alloc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlBuffer>())).contentIO as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlBuffer),
-      "::",
-      stringify!(contentIO)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlBuffer>())).content as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlBuffer),
+  //     "::",
+  //     stringify!(content)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlBuffer>())).use_ as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlBuffer),
+  //     "::",
+  //     stringify!(use_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlBuffer>())).size as *const _ as usize },
+  //   12usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlBuffer),
+  //     "::",
+  //     stringify!(size)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlBuffer>())).alloc as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlBuffer),
+  //     "::",
+  //     stringify!(alloc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlBuffer>())).contentIO as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlBuffer),
+  //     "::",
+  //     stringify!(contentIO)
+  //   )
+  // );
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1716,36 +1716,36 @@ fn bindgen_test_layout__xmlNotation() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlNotation))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNotation>())).name as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNotation),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNotation>())).PublicID as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNotation),
-      "::",
-      stringify!(PublicID)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNotation>())).SystemID as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNotation),
-      "::",
-      stringify!(SystemID)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNotation>())).name as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNotation),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNotation>())).PublicID as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNotation),
+  //     "::",
+  //     stringify!(PublicID)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNotation>())).SystemID as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNotation),
+  //     "::",
+  //     stringify!(SystemID)
+  //   )
+  // );
 }
 pub const xmlAttributeType_XML_ATTRIBUTE_CDATA: xmlAttributeType = 1;
 pub const xmlAttributeType_XML_ATTRIBUTE_ID: xmlAttributeType = 2;
@@ -1792,26 +1792,26 @@ fn bindgen_test_layout__xmlEnumeration() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlEnumeration))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEnumeration>())).next as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEnumeration),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEnumeration>())).name as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEnumeration),
-      "::",
-      stringify!(name)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEnumeration>())).next as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEnumeration),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEnumeration>())).name as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEnumeration),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
 }
 /// xmlAttribute:
 ///
@@ -1850,166 +1850,166 @@ fn bindgen_test_layout__xmlAttribute() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlAttribute))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttribute>()))._private as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttribute),
-      "::",
-      stringify!(_private)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).type_ as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttribute),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).name as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttribute),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).children as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttribute),
-      "::",
-      stringify!(children)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).last as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttribute),
-      "::",
-      stringify!(last)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).parent as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttribute),
-      "::",
-      stringify!(parent)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).next as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttribute),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).prev as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttribute),
-      "::",
-      stringify!(prev)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).doc as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttribute),
-      "::",
-      stringify!(doc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).nexth as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttribute),
-      "::",
-      stringify!(nexth)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).atype as *const _ as usize },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttribute),
-      "::",
-      stringify!(atype)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).def as *const _ as usize },
-    84usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttribute),
-      "::",
-      stringify!(def)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).defaultValue as *const _ as usize },
-    88usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttribute),
-      "::",
-      stringify!(defaultValue)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).tree as *const _ as usize },
-    96usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttribute),
-      "::",
-      stringify!(tree)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).prefix as *const _ as usize },
-    104usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttribute),
-      "::",
-      stringify!(prefix)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).elem as *const _ as usize },
-    112usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttribute),
-      "::",
-      stringify!(elem)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttribute>()))._private as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttribute),
+  //     "::",
+  //     stringify!(_private)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).type_ as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttribute),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).name as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttribute),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).children as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttribute),
+  //     "::",
+  //     stringify!(children)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).last as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttribute),
+  //     "::",
+  //     stringify!(last)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).parent as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttribute),
+  //     "::",
+  //     stringify!(parent)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).next as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttribute),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).prev as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttribute),
+  //     "::",
+  //     stringify!(prev)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).doc as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttribute),
+  //     "::",
+  //     stringify!(doc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).nexth as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttribute),
+  //     "::",
+  //     stringify!(nexth)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).atype as *const _ as usize },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttribute),
+  //     "::",
+  //     stringify!(atype)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).def as *const _ as usize },
+  //   84usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttribute),
+  //     "::",
+  //     stringify!(def)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).defaultValue as *const _ as usize },
+  //   88usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttribute),
+  //     "::",
+  //     stringify!(defaultValue)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).tree as *const _ as usize },
+  //   96usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttribute),
+  //     "::",
+  //     stringify!(tree)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).prefix as *const _ as usize },
+  //   104usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttribute),
+  //     "::",
+  //     stringify!(prefix)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttribute>())).elem as *const _ as usize },
+  //   112usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttribute),
+  //     "::",
+  //     stringify!(elem)
+  //   )
+  // );
 }
 pub const xmlElementContentType_XML_ELEMENT_CONTENT_PCDATA: xmlElementContentType = 1;
 pub const xmlElementContentType_XML_ELEMENT_CONTENT_ELEMENT: xmlElementContentType = 2;
@@ -2056,76 +2056,76 @@ fn bindgen_test_layout__xmlElementContent() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlElementContent))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElementContent>())).type_ as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElementContent),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElementContent>())).ocur as *const _ as usize },
-    4usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElementContent),
-      "::",
-      stringify!(ocur)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElementContent>())).name as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElementContent),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElementContent>())).c1 as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElementContent),
-      "::",
-      stringify!(c1)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElementContent>())).c2 as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElementContent),
-      "::",
-      stringify!(c2)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElementContent>())).parent as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElementContent),
-      "::",
-      stringify!(parent)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElementContent>())).prefix as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElementContent),
-      "::",
-      stringify!(prefix)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElementContent>())).type_ as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElementContent),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElementContent>())).ocur as *const _ as usize },
+  //   4usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElementContent),
+  //     "::",
+  //     stringify!(ocur)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElementContent>())).name as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElementContent),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElementContent>())).c1 as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElementContent),
+  //     "::",
+  //     stringify!(c1)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElementContent>())).c2 as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElementContent),
+  //     "::",
+  //     stringify!(c2)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElementContent>())).parent as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElementContent),
+  //     "::",
+  //     stringify!(parent)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElementContent>())).prefix as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElementContent),
+  //     "::",
+  //     stringify!(prefix)
+  //   )
+  // );
 }
 pub const xmlElementTypeVal_XML_ELEMENT_TYPE_UNDEFINED: xmlElementTypeVal = 0;
 pub const xmlElementTypeVal_XML_ELEMENT_TYPE_EMPTY: xmlElementTypeVal = 1;
@@ -2450,146 +2450,146 @@ fn bindgen_test_layout__xmlElement() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlElement))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElement>()))._private as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElement),
-      "::",
-      stringify!(_private)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElement>())).type_ as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElement),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElement>())).name as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElement),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElement>())).children as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElement),
-      "::",
-      stringify!(children)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElement>())).last as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElement),
-      "::",
-      stringify!(last)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElement>())).parent as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElement),
-      "::",
-      stringify!(parent)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElement>())).next as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElement),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElement>())).prev as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElement),
-      "::",
-      stringify!(prev)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElement>())).doc as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElement),
-      "::",
-      stringify!(doc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElement>())).etype as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElement),
-      "::",
-      stringify!(etype)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElement>())).content as *const _ as usize },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElement),
-      "::",
-      stringify!(content)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElement>())).attributes as *const _ as usize },
-    88usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElement),
-      "::",
-      stringify!(attributes)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElement>())).prefix as *const _ as usize },
-    96usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElement),
-      "::",
-      stringify!(prefix)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlElement>())).contModel as *const _ as usize },
-    104usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlElement),
-      "::",
-      stringify!(contModel)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElement>()))._private as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElement),
+  //     "::",
+  //     stringify!(_private)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElement>())).type_ as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElement),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElement>())).name as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElement),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElement>())).children as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElement),
+  //     "::",
+  //     stringify!(children)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElement>())).last as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElement),
+  //     "::",
+  //     stringify!(last)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElement>())).parent as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElement),
+  //     "::",
+  //     stringify!(parent)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElement>())).next as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElement),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElement>())).prev as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElement),
+  //     "::",
+  //     stringify!(prev)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElement>())).doc as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElement),
+  //     "::",
+  //     stringify!(doc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElement>())).etype as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElement),
+  //     "::",
+  //     stringify!(etype)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElement>())).content as *const _ as usize },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElement),
+  //     "::",
+  //     stringify!(content)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElement>())).attributes as *const _ as usize },
+  //   88usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElement),
+  //     "::",
+  //     stringify!(attributes)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElement>())).prefix as *const _ as usize },
+  //   96usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElement),
+  //     "::",
+  //     stringify!(prefix)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlElement>())).contModel as *const _ as usize },
+  //   104usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlElement),
+  //     "::",
+  //     stringify!(contModel)
+  //   )
+  // );
 }
 pub use self::xmlElementType as xmlNsType;
 /// xmlNs:
@@ -2623,66 +2623,66 @@ fn bindgen_test_layout__xmlNs() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlNs))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNs>())).next as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNs),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNs>())).type_ as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNs),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNs>())).href as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNs),
-      "::",
-      stringify!(href)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNs>())).prefix as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNs),
-      "::",
-      stringify!(prefix)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNs>()))._private as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNs),
-      "::",
-      stringify!(_private)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNs>())).context as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNs),
-      "::",
-      stringify!(context)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNs>())).next as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNs),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNs>())).type_ as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNs),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNs>())).href as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNs),
+  //     "::",
+  //     stringify!(href)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNs>())).prefix as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNs),
+  //     "::",
+  //     stringify!(prefix)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNs>()))._private as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNs),
+  //     "::",
+  //     stringify!(_private)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNs>())).context as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNs),
+  //     "::",
+  //     stringify!(context)
+  //   )
+  // );
 }
 /// xmlDtd:
 ///
@@ -2722,166 +2722,166 @@ fn bindgen_test_layout__xmlDtd() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlDtd))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDtd>()))._private as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDtd),
-      "::",
-      stringify!(_private)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDtd>())).type_ as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDtd),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDtd>())).name as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDtd),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDtd>())).children as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDtd),
-      "::",
-      stringify!(children)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDtd>())).last as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDtd),
-      "::",
-      stringify!(last)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDtd>())).parent as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDtd),
-      "::",
-      stringify!(parent)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDtd>())).next as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDtd),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDtd>())).prev as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDtd),
-      "::",
-      stringify!(prev)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDtd>())).doc as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDtd),
-      "::",
-      stringify!(doc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDtd>())).notations as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDtd),
-      "::",
-      stringify!(notations)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDtd>())).elements as *const _ as usize },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDtd),
-      "::",
-      stringify!(elements)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDtd>())).attributes as *const _ as usize },
-    88usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDtd),
-      "::",
-      stringify!(attributes)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDtd>())).entities as *const _ as usize },
-    96usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDtd),
-      "::",
-      stringify!(entities)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDtd>())).ExternalID as *const _ as usize },
-    104usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDtd),
-      "::",
-      stringify!(ExternalID)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDtd>())).SystemID as *const _ as usize },
-    112usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDtd),
-      "::",
-      stringify!(SystemID)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDtd>())).pentities as *const _ as usize },
-    120usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDtd),
-      "::",
-      stringify!(pentities)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDtd>()))._private as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDtd),
+  //     "::",
+  //     stringify!(_private)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDtd>())).type_ as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDtd),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDtd>())).name as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDtd),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDtd>())).children as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDtd),
+  //     "::",
+  //     stringify!(children)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDtd>())).last as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDtd),
+  //     "::",
+  //     stringify!(last)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDtd>())).parent as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDtd),
+  //     "::",
+  //     stringify!(parent)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDtd>())).next as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDtd),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDtd>())).prev as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDtd),
+  //     "::",
+  //     stringify!(prev)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDtd>())).doc as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDtd),
+  //     "::",
+  //     stringify!(doc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDtd>())).notations as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDtd),
+  //     "::",
+  //     stringify!(notations)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDtd>())).elements as *const _ as usize },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDtd),
+  //     "::",
+  //     stringify!(elements)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDtd>())).attributes as *const _ as usize },
+  //   88usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDtd),
+  //     "::",
+  //     stringify!(attributes)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDtd>())).entities as *const _ as usize },
+  //   96usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDtd),
+  //     "::",
+  //     stringify!(entities)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDtd>())).ExternalID as *const _ as usize },
+  //   104usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDtd),
+  //     "::",
+  //     stringify!(ExternalID)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDtd>())).SystemID as *const _ as usize },
+  //   112usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDtd),
+  //     "::",
+  //     stringify!(SystemID)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDtd>())).pentities as *const _ as usize },
+  //   120usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDtd),
+  //     "::",
+  //     stringify!(pentities)
+  //   )
+  // );
 }
 /// xmlAttr:
 ///
@@ -2916,126 +2916,126 @@ fn bindgen_test_layout__xmlAttr() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlAttr))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttr>()))._private as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttr),
-      "::",
-      stringify!(_private)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttr>())).type_ as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttr),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttr>())).name as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttr),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttr>())).children as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttr),
-      "::",
-      stringify!(children)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttr>())).last as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttr),
-      "::",
-      stringify!(last)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttr>())).parent as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttr),
-      "::",
-      stringify!(parent)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttr>())).next as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttr),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttr>())).prev as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttr),
-      "::",
-      stringify!(prev)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttr>())).doc as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttr),
-      "::",
-      stringify!(doc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttr>())).ns as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttr),
-      "::",
-      stringify!(ns)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttr>())).atype as *const _ as usize },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttr),
-      "::",
-      stringify!(atype)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlAttr>())).psvi as *const _ as usize },
-    88usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlAttr),
-      "::",
-      stringify!(psvi)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttr>()))._private as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttr),
+  //     "::",
+  //     stringify!(_private)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttr>())).type_ as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttr),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttr>())).name as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttr),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttr>())).children as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttr),
+  //     "::",
+  //     stringify!(children)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttr>())).last as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttr),
+  //     "::",
+  //     stringify!(last)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttr>())).parent as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttr),
+  //     "::",
+  //     stringify!(parent)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttr>())).next as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttr),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttr>())).prev as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttr),
+  //     "::",
+  //     stringify!(prev)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttr>())).doc as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttr),
+  //     "::",
+  //     stringify!(doc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttr>())).ns as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttr),
+  //     "::",
+  //     stringify!(ns)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttr>())).atype as *const _ as usize },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttr),
+  //     "::",
+  //     stringify!(atype)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlAttr>())).psvi as *const _ as usize },
+  //   88usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlAttr),
+  //     "::",
+  //     stringify!(psvi)
+  //   )
+  // );
 }
 /// xmlID:
 ///
@@ -3064,66 +3064,66 @@ fn bindgen_test_layout__xmlID() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlID))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlID>())).next as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlID),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlID>())).value as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlID),
-      "::",
-      stringify!(value)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlID>())).attr as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlID),
-      "::",
-      stringify!(attr)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlID>())).name as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlID),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlID>())).lineno as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlID),
-      "::",
-      stringify!(lineno)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlID>())).doc as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlID),
-      "::",
-      stringify!(doc)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlID>())).next as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlID),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlID>())).value as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlID),
+  //     "::",
+  //     stringify!(value)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlID>())).attr as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlID),
+  //     "::",
+  //     stringify!(attr)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlID>())).name as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlID),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlID>())).lineno as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlID),
+  //     "::",
+  //     stringify!(lineno)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlID>())).doc as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlID),
+  //     "::",
+  //     stringify!(doc)
+  //   )
+  // );
 }
 /// xmlRef:
 ///
@@ -3151,56 +3151,56 @@ fn bindgen_test_layout__xmlRef() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlRef))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlRef>())).next as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlRef),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlRef>())).value as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlRef),
-      "::",
-      stringify!(value)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlRef>())).attr as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlRef),
-      "::",
-      stringify!(attr)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlRef>())).name as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlRef),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlRef>())).lineno as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlRef),
-      "::",
-      stringify!(lineno)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlRef>())).next as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlRef),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlRef>())).value as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlRef),
+  //     "::",
+  //     stringify!(value)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlRef>())).attr as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlRef),
+  //     "::",
+  //     stringify!(attr)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlRef>())).name as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlRef),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlRef>())).lineno as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlRef),
+  //     "::",
+  //     stringify!(lineno)
+  //   )
+  // );
 }
 /// xmlNode:
 ///
@@ -3239,166 +3239,166 @@ fn bindgen_test_layout__xmlNode() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlNode))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNode>()))._private as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNode),
-      "::",
-      stringify!(_private)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNode>())).type_ as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNode),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNode>())).name as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNode),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNode>())).children as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNode),
-      "::",
-      stringify!(children)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNode>())).last as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNode),
-      "::",
-      stringify!(last)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNode>())).parent as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNode),
-      "::",
-      stringify!(parent)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNode>())).next as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNode),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNode>())).prev as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNode),
-      "::",
-      stringify!(prev)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNode>())).doc as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNode),
-      "::",
-      stringify!(doc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNode>())).ns as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNode),
-      "::",
-      stringify!(ns)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNode>())).content as *const _ as usize },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNode),
-      "::",
-      stringify!(content)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNode>())).properties as *const _ as usize },
-    88usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNode),
-      "::",
-      stringify!(properties)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNode>())).nsDef as *const _ as usize },
-    96usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNode),
-      "::",
-      stringify!(nsDef)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNode>())).psvi as *const _ as usize },
-    104usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNode),
-      "::",
-      stringify!(psvi)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNode>())).line as *const _ as usize },
-    112usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNode),
-      "::",
-      stringify!(line)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNode>())).extra as *const _ as usize },
-    114usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNode),
-      "::",
-      stringify!(extra)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNode>()))._private as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNode),
+  //     "::",
+  //     stringify!(_private)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNode>())).type_ as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNode),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNode>())).name as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNode),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNode>())).children as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNode),
+  //     "::",
+  //     stringify!(children)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNode>())).last as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNode),
+  //     "::",
+  //     stringify!(last)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNode>())).parent as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNode),
+  //     "::",
+  //     stringify!(parent)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNode>())).next as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNode),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNode>())).prev as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNode),
+  //     "::",
+  //     stringify!(prev)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNode>())).doc as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNode),
+  //     "::",
+  //     stringify!(doc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNode>())).ns as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNode),
+  //     "::",
+  //     stringify!(ns)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNode>())).content as *const _ as usize },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNode),
+  //     "::",
+  //     stringify!(content)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNode>())).properties as *const _ as usize },
+  //   88usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNode),
+  //     "::",
+  //     stringify!(properties)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNode>())).nsDef as *const _ as usize },
+  //   96usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNode),
+  //     "::",
+  //     stringify!(nsDef)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNode>())).psvi as *const _ as usize },
+  //   104usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNode),
+  //     "::",
+  //     stringify!(psvi)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNode>())).line as *const _ as usize },
+  //   112usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNode),
+  //     "::",
+  //     stringify!(line)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNode>())).extra as *const _ as usize },
+  //   114usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNode),
+  //     "::",
+  //     stringify!(extra)
+  //   )
+  // );
 }
 pub const xmlDocProperties_XML_DOC_WELLFORMED: xmlDocProperties = 1;
 pub const xmlDocProperties_XML_DOC_NSVALID: xmlDocProperties = 2;
@@ -3458,246 +3458,246 @@ fn bindgen_test_layout__xmlDoc() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlDoc))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>()))._private as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(_private)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).type_ as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).name as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).children as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(children)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).last as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(last)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).parent as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(parent)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).next as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).prev as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(prev)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).doc as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(doc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).compression as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(compression)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).standalone as *const _ as usize },
-    76usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(standalone)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).intSubset as *const _ as usize },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(intSubset)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).extSubset as *const _ as usize },
-    88usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(extSubset)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).oldNs as *const _ as usize },
-    96usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(oldNs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).version as *const _ as usize },
-    104usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(version)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).encoding as *const _ as usize },
-    112usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(encoding)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).ids as *const _ as usize },
-    120usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(ids)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).refs as *const _ as usize },
-    128usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(refs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).URL as *const _ as usize },
-    136usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(URL)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).charset as *const _ as usize },
-    144usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(charset)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).dict as *const _ as usize },
-    152usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(dict)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).psvi as *const _ as usize },
-    160usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(psvi)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).parseFlags as *const _ as usize },
-    168usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(parseFlags)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDoc>())).properties as *const _ as usize },
-    172usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDoc),
-      "::",
-      stringify!(properties)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>()))._private as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(_private)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).type_ as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).name as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).children as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(children)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).last as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(last)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).parent as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(parent)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).next as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).prev as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(prev)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).doc as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(doc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).compression as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(compression)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).standalone as *const _ as usize },
+  //   76usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(standalone)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).intSubset as *const _ as usize },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(intSubset)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).extSubset as *const _ as usize },
+  //   88usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(extSubset)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).oldNs as *const _ as usize },
+  //   96usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(oldNs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).version as *const _ as usize },
+  //   104usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(version)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).encoding as *const _ as usize },
+  //   112usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(encoding)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).ids as *const _ as usize },
+  //   120usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(ids)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).refs as *const _ as usize },
+  //   128usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(refs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).URL as *const _ as usize },
+  //   136usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(URL)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).charset as *const _ as usize },
+  //   144usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(charset)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).dict as *const _ as usize },
+  //   152usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(dict)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).psvi as *const _ as usize },
+  //   160usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(psvi)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).parseFlags as *const _ as usize },
+  //   168usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(parseFlags)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDoc>())).properties as *const _ as usize },
+  //   172usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDoc),
+  //     "::",
+  //     stringify!(properties)
+  //   )
+  // );
 }
 pub type xmlDOMWrapCtxt = _xmlDOMWrapCtxt;
 pub type xmlDOMWrapCtxtPtr = *mut xmlDOMWrapCtxt;
@@ -3741,46 +3741,46 @@ fn bindgen_test_layout__xmlDOMWrapCtxt() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlDOMWrapCtxt))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDOMWrapCtxt>()))._private as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDOMWrapCtxt),
-      "::",
-      stringify!(_private)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDOMWrapCtxt>())).type_ as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDOMWrapCtxt),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDOMWrapCtxt>())).namespaceMap as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDOMWrapCtxt),
-      "::",
-      stringify!(namespaceMap)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlDOMWrapCtxt>())).getNsForNodeFunc as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlDOMWrapCtxt),
-      "::",
-      stringify!(getNsForNodeFunc)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDOMWrapCtxt>()))._private as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDOMWrapCtxt),
+  //     "::",
+  //     stringify!(_private)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDOMWrapCtxt>())).type_ as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDOMWrapCtxt),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDOMWrapCtxt>())).namespaceMap as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDOMWrapCtxt),
+  //     "::",
+  //     stringify!(namespaceMap)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlDOMWrapCtxt>())).getNsForNodeFunc as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlDOMWrapCtxt),
+  //     "::",
+  //     stringify!(getNsForNodeFunc)
+  //   )
+  // );
 }
 extern "C" {
   pub fn xmlValidateNCName(
@@ -4775,136 +4775,136 @@ fn bindgen_test_layout__xmlError() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlError))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlError>())).domain as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlError),
-      "::",
-      stringify!(domain)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlError>())).code as *const _ as usize },
-    4usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlError),
-      "::",
-      stringify!(code)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlError>())).message as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlError),
-      "::",
-      stringify!(message)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlError>())).level as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlError),
-      "::",
-      stringify!(level)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlError>())).file as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlError),
-      "::",
-      stringify!(file)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlError>())).line as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlError),
-      "::",
-      stringify!(line)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlError>())).str1 as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlError),
-      "::",
-      stringify!(str1)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlError>())).str2 as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlError),
-      "::",
-      stringify!(str2)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlError>())).str3 as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlError),
-      "::",
-      stringify!(str3)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlError>())).int1 as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlError),
-      "::",
-      stringify!(int1)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlError>())).int2 as *const _ as usize },
-    68usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlError),
-      "::",
-      stringify!(int2)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlError>())).ctxt as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlError),
-      "::",
-      stringify!(ctxt)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlError>())).node as *const _ as usize },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlError),
-      "::",
-      stringify!(node)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlError>())).domain as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlError),
+  //     "::",
+  //     stringify!(domain)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlError>())).code as *const _ as usize },
+  //   4usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlError),
+  //     "::",
+  //     stringify!(code)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlError>())).message as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlError),
+  //     "::",
+  //     stringify!(message)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlError>())).level as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlError),
+  //     "::",
+  //     stringify!(level)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlError>())).file as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlError),
+  //     "::",
+  //     stringify!(file)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlError>())).line as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlError),
+  //     "::",
+  //     stringify!(line)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlError>())).str1 as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlError),
+  //     "::",
+  //     stringify!(str1)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlError>())).str2 as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlError),
+  //     "::",
+  //     stringify!(str2)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlError>())).str3 as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlError),
+  //     "::",
+  //     stringify!(str3)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlError>())).int1 as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlError),
+  //     "::",
+  //     stringify!(int1)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlError>())).int2 as *const _ as usize },
+  //   68usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlError),
+  //     "::",
+  //     stringify!(int2)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlError>())).ctxt as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlError),
+  //     "::",
+  //     stringify!(ctxt)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlError>())).node as *const _ as usize },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlError),
+  //     "::",
+  //     stringify!(node)
+  //   )
+  // );
 }
 pub const xmlParserErrors_XML_ERR_OK: xmlParserErrors = 0;
 pub const xmlParserErrors_XML_ERR_INTERNAL_ERROR: xmlParserErrors = 1;
@@ -6090,166 +6090,166 @@ fn bindgen_test_layout__xmlValidCtxt() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlValidCtxt))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).userData as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlValidCtxt),
-      "::",
-      stringify!(userData)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).error as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlValidCtxt),
-      "::",
-      stringify!(error)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).warning as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlValidCtxt),
-      "::",
-      stringify!(warning)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).node as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlValidCtxt),
-      "::",
-      stringify!(node)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).nodeNr as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlValidCtxt),
-      "::",
-      stringify!(nodeNr)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).nodeMax as *const _ as usize },
-    36usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlValidCtxt),
-      "::",
-      stringify!(nodeMax)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).nodeTab as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlValidCtxt),
-      "::",
-      stringify!(nodeTab)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).finishDtd as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlValidCtxt),
-      "::",
-      stringify!(finishDtd)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).doc as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlValidCtxt),
-      "::",
-      stringify!(doc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).valid as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlValidCtxt),
-      "::",
-      stringify!(valid)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).vstate as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlValidCtxt),
-      "::",
-      stringify!(vstate)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).vstateNr as *const _ as usize },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlValidCtxt),
-      "::",
-      stringify!(vstateNr)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).vstateMax as *const _ as usize },
-    84usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlValidCtxt),
-      "::",
-      stringify!(vstateMax)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).vstateTab as *const _ as usize },
-    88usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlValidCtxt),
-      "::",
-      stringify!(vstateTab)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).am as *const _ as usize },
-    96usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlValidCtxt),
-      "::",
-      stringify!(am)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).state as *const _ as usize },
-    104usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlValidCtxt),
-      "::",
-      stringify!(state)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).userData as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlValidCtxt),
+  //     "::",
+  //     stringify!(userData)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).error as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlValidCtxt),
+  //     "::",
+  //     stringify!(error)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).warning as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlValidCtxt),
+  //     "::",
+  //     stringify!(warning)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).node as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlValidCtxt),
+  //     "::",
+  //     stringify!(node)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).nodeNr as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlValidCtxt),
+  //     "::",
+  //     stringify!(nodeNr)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).nodeMax as *const _ as usize },
+  //   36usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlValidCtxt),
+  //     "::",
+  //     stringify!(nodeMax)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).nodeTab as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlValidCtxt),
+  //     "::",
+  //     stringify!(nodeTab)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).finishDtd as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlValidCtxt),
+  //     "::",
+  //     stringify!(finishDtd)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).doc as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlValidCtxt),
+  //     "::",
+  //     stringify!(doc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).valid as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlValidCtxt),
+  //     "::",
+  //     stringify!(valid)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).vstate as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlValidCtxt),
+  //     "::",
+  //     stringify!(vstate)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).vstateNr as *const _ as usize },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlValidCtxt),
+  //     "::",
+  //     stringify!(vstateNr)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).vstateMax as *const _ as usize },
+  //   84usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlValidCtxt),
+  //     "::",
+  //     stringify!(vstateMax)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).vstateTab as *const _ as usize },
+  //   88usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlValidCtxt),
+  //     "::",
+  //     stringify!(vstateTab)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).am as *const _ as usize },
+  //   96usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlValidCtxt),
+  //     "::",
+  //     stringify!(am)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlValidCtxt>())).state as *const _ as usize },
+  //   104usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlValidCtxt),
+  //     "::",
+  //     stringify!(state)
+  //   )
+  // );
 }
 pub type xmlNotationTable = _xmlHashTable;
 pub type xmlNotationTablePtr = *mut xmlNotationTable;
@@ -6659,196 +6659,196 @@ fn bindgen_test_layout__xmlEntity() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlEntity))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>()))._private as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(_private)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).type_ as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).name as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).children as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(children)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).last as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(last)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).parent as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(parent)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).next as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).prev as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(prev)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).doc as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(doc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).orig as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(orig)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).content as *const _ as usize },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(content)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).length as *const _ as usize },
-    88usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(length)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).etype as *const _ as usize },
-    92usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(etype)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).ExternalID as *const _ as usize },
-    96usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(ExternalID)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).SystemID as *const _ as usize },
-    104usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(SystemID)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).nexte as *const _ as usize },
-    112usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(nexte)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).URI as *const _ as usize },
-    120usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(URI)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).owner as *const _ as usize },
-    128usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(owner)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlEntity>())).checked as *const _ as usize },
-    132usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlEntity),
-      "::",
-      stringify!(checked)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>()))._private as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(_private)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).type_ as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).name as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).children as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(children)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).last as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(last)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).parent as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(parent)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).next as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).prev as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(prev)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).doc as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(doc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).orig as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(orig)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).content as *const _ as usize },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(content)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).length as *const _ as usize },
+  //   88usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(length)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).etype as *const _ as usize },
+  //   92usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(etype)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).ExternalID as *const _ as usize },
+  //   96usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(ExternalID)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).SystemID as *const _ as usize },
+  //   104usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(SystemID)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).nexte as *const _ as usize },
+  //   112usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(nexte)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).URI as *const _ as usize },
+  //   120usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(URI)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).owner as *const _ as usize },
+  //   128usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(owner)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlEntity>())).checked as *const _ as usize },
+  //   132usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlEntity),
+  //     "::",
+  //     stringify!(checked)
+  //   )
+  // );
 }
 pub type xmlEntitiesTable = _xmlHashTable;
 pub type xmlEntitiesTablePtr = *mut xmlEntitiesTable;
@@ -7637,30 +7637,30 @@ fn bindgen_test_layout_max_align_t() {
   //   32usize,
   //   concat!("Size of: ", stringify!(max_align_t))
   // );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<max_align_t>())).__clang_max_align_nonce1 as *const _ as usize
-    },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(max_align_t),
-      "::",
-      stringify!(__clang_max_align_nonce1)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<max_align_t>())).__clang_max_align_nonce2 as *const _ as usize
-    },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(max_align_t),
-      "::",
-      stringify!(__clang_max_align_nonce2)
-    )
-  );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<max_align_t>())).__clang_max_align_nonce1 as *const _ as usize
+  //   },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(max_align_t),
+  //     "::",
+  //     stringify!(__clang_max_align_nonce1)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<max_align_t>())).__clang_max_align_nonce2 as *const _ as usize
+  //   },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(max_align_t),
+  //     "::",
+  //     stringify!(__clang_max_align_nonce2)
+  //   )
+  // );
 }
 pub type int_least8_t = ::std::os::raw::c_schar;
 pub type int_least16_t = ::std::os::raw::c_short;
@@ -7935,90 +7935,90 @@ fn bindgen_test_layout_UConverterFromUnicodeArgs() {
     8usize,
     concat!("Alignment of ", stringify!(UConverterFromUnicodeArgs))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<UConverterFromUnicodeArgs>())).size as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(UConverterFromUnicodeArgs),
-      "::",
-      stringify!(size)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<UConverterFromUnicodeArgs>())).flush as *const _ as usize },
-    2usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(UConverterFromUnicodeArgs),
-      "::",
-      stringify!(flush)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<UConverterFromUnicodeArgs>())).converter as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(UConverterFromUnicodeArgs),
-      "::",
-      stringify!(converter)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<UConverterFromUnicodeArgs>())).source as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(UConverterFromUnicodeArgs),
-      "::",
-      stringify!(source)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<UConverterFromUnicodeArgs>())).sourceLimit as *const _ as usize
-    },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(UConverterFromUnicodeArgs),
-      "::",
-      stringify!(sourceLimit)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<UConverterFromUnicodeArgs>())).target as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(UConverterFromUnicodeArgs),
-      "::",
-      stringify!(target)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<UConverterFromUnicodeArgs>())).targetLimit as *const _ as usize
-    },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(UConverterFromUnicodeArgs),
-      "::",
-      stringify!(targetLimit)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<UConverterFromUnicodeArgs>())).offsets as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(UConverterFromUnicodeArgs),
-      "::",
-      stringify!(offsets)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<UConverterFromUnicodeArgs>())).size as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(UConverterFromUnicodeArgs),
+  //     "::",
+  //     stringify!(size)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<UConverterFromUnicodeArgs>())).flush as *const _ as usize },
+  //   2usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(UConverterFromUnicodeArgs),
+  //     "::",
+  //     stringify!(flush)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<UConverterFromUnicodeArgs>())).converter as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(UConverterFromUnicodeArgs),
+  //     "::",
+  //     stringify!(converter)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<UConverterFromUnicodeArgs>())).source as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(UConverterFromUnicodeArgs),
+  //     "::",
+  //     stringify!(source)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<UConverterFromUnicodeArgs>())).sourceLimit as *const _ as usize
+  //   },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(UConverterFromUnicodeArgs),
+  //     "::",
+  //     stringify!(sourceLimit)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<UConverterFromUnicodeArgs>())).target as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(UConverterFromUnicodeArgs),
+  //     "::",
+  //     stringify!(target)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<UConverterFromUnicodeArgs>())).targetLimit as *const _ as usize
+  //   },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(UConverterFromUnicodeArgs),
+  //     "::",
+  //     stringify!(targetLimit)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<UConverterFromUnicodeArgs>())).offsets as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(UConverterFromUnicodeArgs),
+  //     "::",
+  //     stringify!(offsets)
+  //   )
+  // );
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -8044,86 +8044,86 @@ fn bindgen_test_layout_UConverterToUnicodeArgs() {
     8usize,
     concat!("Alignment of ", stringify!(UConverterToUnicodeArgs))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<UConverterToUnicodeArgs>())).size as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(UConverterToUnicodeArgs),
-      "::",
-      stringify!(size)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<UConverterToUnicodeArgs>())).flush as *const _ as usize },
-    2usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(UConverterToUnicodeArgs),
-      "::",
-      stringify!(flush)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<UConverterToUnicodeArgs>())).converter as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(UConverterToUnicodeArgs),
-      "::",
-      stringify!(converter)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<UConverterToUnicodeArgs>())).source as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(UConverterToUnicodeArgs),
-      "::",
-      stringify!(source)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<UConverterToUnicodeArgs>())).sourceLimit as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(UConverterToUnicodeArgs),
-      "::",
-      stringify!(sourceLimit)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<UConverterToUnicodeArgs>())).target as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(UConverterToUnicodeArgs),
-      "::",
-      stringify!(target)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<UConverterToUnicodeArgs>())).targetLimit as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(UConverterToUnicodeArgs),
-      "::",
-      stringify!(targetLimit)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<UConverterToUnicodeArgs>())).offsets as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(UConverterToUnicodeArgs),
-      "::",
-      stringify!(offsets)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<UConverterToUnicodeArgs>())).size as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(UConverterToUnicodeArgs),
+  //     "::",
+  //     stringify!(size)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<UConverterToUnicodeArgs>())).flush as *const _ as usize },
+  //   2usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(UConverterToUnicodeArgs),
+  //     "::",
+  //     stringify!(flush)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<UConverterToUnicodeArgs>())).converter as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(UConverterToUnicodeArgs),
+  //     "::",
+  //     stringify!(converter)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<UConverterToUnicodeArgs>())).source as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(UConverterToUnicodeArgs),
+  //     "::",
+  //     stringify!(source)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<UConverterToUnicodeArgs>())).sourceLimit as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(UConverterToUnicodeArgs),
+  //     "::",
+  //     stringify!(sourceLimit)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<UConverterToUnicodeArgs>())).target as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(UConverterToUnicodeArgs),
+  //     "::",
+  //     stringify!(target)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<UConverterToUnicodeArgs>())).targetLimit as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(UConverterToUnicodeArgs),
+  //     "::",
+  //     stringify!(targetLimit)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<UConverterToUnicodeArgs>())).offsets as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(UConverterToUnicodeArgs),
+  //     "::",
+  //     stringify!(offsets)
+  //   )
+  // );
 }
 extern "C" {
   pub fn UCNV_FROM_U_CALLBACK_STOP_60(
@@ -8778,26 +8778,26 @@ fn bindgen_test_layout__uconv_t() {
     8usize,
     concat!("Alignment of ", stringify!(_uconv_t))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_uconv_t>())).uconv as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_uconv_t),
-      "::",
-      stringify!(uconv)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_uconv_t>())).utf8 as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_uconv_t),
-      "::",
-      stringify!(utf8)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_uconv_t>())).uconv as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_uconv_t),
+  //     "::",
+  //     stringify!(uconv)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_uconv_t>())).utf8 as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_uconv_t),
+  //     "::",
+  //     stringify!(utf8)
+  //   )
+  // );
 }
 pub type uconv_t = _uconv_t;
 pub type xmlCharEncodingHandler = _xmlCharEncodingHandler;
@@ -8825,76 +8825,76 @@ fn bindgen_test_layout__xmlCharEncodingHandler() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlCharEncodingHandler))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlCharEncodingHandler>())).name as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlCharEncodingHandler),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlCharEncodingHandler>())).input as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlCharEncodingHandler),
-      "::",
-      stringify!(input)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlCharEncodingHandler>())).output as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlCharEncodingHandler),
-      "::",
-      stringify!(output)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlCharEncodingHandler>())).iconv_in as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlCharEncodingHandler),
-      "::",
-      stringify!(iconv_in)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlCharEncodingHandler>())).iconv_out as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlCharEncodingHandler),
-      "::",
-      stringify!(iconv_out)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlCharEncodingHandler>())).uconv_in as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlCharEncodingHandler),
-      "::",
-      stringify!(uconv_in)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlCharEncodingHandler>())).uconv_out as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlCharEncodingHandler),
-      "::",
-      stringify!(uconv_out)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlCharEncodingHandler>())).name as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlCharEncodingHandler),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlCharEncodingHandler>())).input as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlCharEncodingHandler),
+  //     "::",
+  //     stringify!(input)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlCharEncodingHandler>())).output as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlCharEncodingHandler),
+  //     "::",
+  //     stringify!(output)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlCharEncodingHandler>())).iconv_in as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlCharEncodingHandler),
+  //     "::",
+  //     stringify!(iconv_in)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlCharEncodingHandler>())).iconv_out as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlCharEncodingHandler),
+  //     "::",
+  //     stringify!(iconv_out)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlCharEncodingHandler>())).uconv_in as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlCharEncodingHandler),
+  //     "::",
+  //     stringify!(uconv_in)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlCharEncodingHandler>())).uconv_out as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlCharEncodingHandler),
+  //     "::",
+  //     stringify!(uconv_out)
+  //   )
+  // );
 }
 extern "C" {
   pub fn xmlInitCharEncodingHandlers();
@@ -9100,26 +9100,26 @@ fn bindgen_test_layout_div_t() {
     4usize,
     concat!("Alignment of ", stringify!(div_t))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<div_t>())).quot as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(div_t),
-      "::",
-      stringify!(quot)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<div_t>())).rem as *const _ as usize },
-    4usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(div_t),
-      "::",
-      stringify!(rem)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<div_t>())).quot as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(div_t),
+  //     "::",
+  //     stringify!(quot)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<div_t>())).rem as *const _ as usize },
+  //   4usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(div_t),
+  //     "::",
+  //     stringify!(rem)
+  //   )
+  // );
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -9146,26 +9146,26 @@ fn bindgen_test_layout_lldiv_t() {
     8usize,
     concat!("Alignment of ", stringify!(lldiv_t))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<lldiv_t>())).quot as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(lldiv_t),
-      "::",
-      stringify!(quot)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<lldiv_t>())).rem as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(lldiv_t),
-      "::",
-      stringify!(rem)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<lldiv_t>())).quot as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(lldiv_t),
+  //     "::",
+  //     stringify!(quot)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<lldiv_t>())).rem as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(lldiv_t),
+  //     "::",
+  //     stringify!(rem)
+  //   )
+  // );
 }
 extern "C" {
   pub fn __ctype_get_mb_cur_max() -> usize;
@@ -9379,26 +9379,26 @@ fn bindgen_test_layout___pthread_internal_list() {
     8usize,
     concat!("Alignment of ", stringify!(__pthread_internal_list))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<__pthread_internal_list>())).__prev as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(__pthread_internal_list),
-      "::",
-      stringify!(__prev)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<__pthread_internal_list>())).__next as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(__pthread_internal_list),
-      "::",
-      stringify!(__next)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<__pthread_internal_list>())).__prev as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(__pthread_internal_list),
+  //     "::",
+  //     stringify!(__prev)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<__pthread_internal_list>())).__next as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(__pthread_internal_list),
+  //     "::",
+  //     stringify!(__next)
+  //   )
+  // );
 }
 pub type __pthread_list_t = __pthread_internal_list;
 #[repr(C)]
@@ -9571,76 +9571,76 @@ fn bindgen_test_layout_random_data() {
     8usize,
     concat!("Alignment of ", stringify!(random_data))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<random_data>())).fptr as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(random_data),
-      "::",
-      stringify!(fptr)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<random_data>())).rptr as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(random_data),
-      "::",
-      stringify!(rptr)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<random_data>())).state as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(random_data),
-      "::",
-      stringify!(state)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<random_data>())).rand_type as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(random_data),
-      "::",
-      stringify!(rand_type)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<random_data>())).rand_deg as *const _ as usize },
-    28usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(random_data),
-      "::",
-      stringify!(rand_deg)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<random_data>())).rand_sep as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(random_data),
-      "::",
-      stringify!(rand_sep)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<random_data>())).end_ptr as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(random_data),
-      "::",
-      stringify!(end_ptr)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<random_data>())).fptr as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(random_data),
+  //     "::",
+  //     stringify!(fptr)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<random_data>())).rptr as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(random_data),
+  //     "::",
+  //     stringify!(rptr)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<random_data>())).state as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(random_data),
+  //     "::",
+  //     stringify!(state)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<random_data>())).rand_type as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(random_data),
+  //     "::",
+  //     stringify!(rand_type)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<random_data>())).rand_deg as *const _ as usize },
+  //   28usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(random_data),
+  //     "::",
+  //     stringify!(rand_deg)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<random_data>())).rand_sep as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(random_data),
+  //     "::",
+  //     stringify!(rand_sep)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<random_data>())).end_ptr as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(random_data),
+  //     "::",
+  //     stringify!(end_ptr)
+  //   )
+  // );
 }
 extern "C" {
   pub fn random_r(__buf: *mut random_data, __result: *mut i32) -> ::std::os::raw::c_int;
@@ -9722,56 +9722,56 @@ fn bindgen_test_layout_drand48_data() {
     8usize,
     concat!("Alignment of ", stringify!(drand48_data))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<drand48_data>())).__x as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(drand48_data),
-      "::",
-      stringify!(__x)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<drand48_data>())).__old_x as *const _ as usize },
-    6usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(drand48_data),
-      "::",
-      stringify!(__old_x)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<drand48_data>())).__c as *const _ as usize },
-    12usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(drand48_data),
-      "::",
-      stringify!(__c)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<drand48_data>())).__init as *const _ as usize },
-    14usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(drand48_data),
-      "::",
-      stringify!(__init)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<drand48_data>())).__a as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(drand48_data),
-      "::",
-      stringify!(__a)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<drand48_data>())).__x as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(drand48_data),
+  //     "::",
+  //     stringify!(__x)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<drand48_data>())).__old_x as *const _ as usize },
+  //   6usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(drand48_data),
+  //     "::",
+  //     stringify!(__old_x)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<drand48_data>())).__c as *const _ as usize },
+  //   12usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(drand48_data),
+  //     "::",
+  //     stringify!(__c)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<drand48_data>())).__init as *const _ as usize },
+  //   14usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(drand48_data),
+  //     "::",
+  //     stringify!(__init)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<drand48_data>())).__a as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(drand48_data),
+  //     "::",
+  //     stringify!(__a)
+  //   )
+  // );
 }
 extern "C" {
   pub fn drand48_r(__buffer: *mut drand48_data, __result: *mut f64) -> ::std::os::raw::c_int;
@@ -10217,36 +10217,36 @@ fn bindgen_test_layout__xlinkHandler() {
     8usize,
     concat!("Alignment of ", stringify!(_xlinkHandler))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xlinkHandler>())).simple as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xlinkHandler),
-      "::",
-      stringify!(simple)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xlinkHandler>())).extended as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xlinkHandler),
-      "::",
-      stringify!(extended)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xlinkHandler>())).set as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xlinkHandler),
-      "::",
-      stringify!(set)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xlinkHandler>())).simple as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xlinkHandler),
+  //     "::",
+  //     stringify!(simple)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xlinkHandler>())).extended as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xlinkHandler),
+  //     "::",
+  //     stringify!(extended)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xlinkHandler>())).set as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xlinkHandler),
+  //     "::",
+  //     stringify!(set)
+  //   )
+  // );
 }
 extern "C" {
   pub fn xlinkGetDefaultDetect() -> xlinkNodeDetectFunc;
@@ -10901,382 +10901,382 @@ fn bindgen_test_layout__xmlGlobalState() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlGlobalState))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlParserVersion as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlParserVersion)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlDefaultSAXLocator as *const _ as usize
-    },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlDefaultSAXLocator)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlDefaultSAXHandler as *const _ as usize
-    },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlDefaultSAXHandler)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).docbDefaultSAXHandler as *const _ as usize
-    },
-    264usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(docbDefaultSAXHandler)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).htmlDefaultSAXHandler as *const _ as usize
-    },
-    488usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(htmlDefaultSAXHandler)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlFree as *const _ as usize },
-    712usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlFree)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlMalloc as *const _ as usize },
-    720usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlMalloc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlMemStrdup as *const _ as usize },
-    728usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlMemStrdup)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlRealloc as *const _ as usize },
-    736usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlRealloc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlGenericError as *const _ as usize },
-    744usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlGenericError)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlStructuredError as *const _ as usize },
-    752usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlStructuredError)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlGenericErrorContext as *const _ as usize
-    },
-    760usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlGenericErrorContext)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).oldXMLWDcompatibility as *const _ as usize
-    },
-    768usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(oldXMLWDcompatibility)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlBufferAllocScheme as *const _ as usize
-    },
-    772usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlBufferAllocScheme)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlDefaultBufferSize as *const _ as usize
-    },
-    776usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlDefaultBufferSize)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlSubstituteEntitiesDefaultValue as *const _
-        as usize
-    },
-    780usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlSubstituteEntitiesDefaultValue)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlDoValidityCheckingDefaultValue as *const _
-        as usize
-    },
-    784usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlDoValidityCheckingDefaultValue)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlGetWarningsDefaultValue as *const _ as usize
-    },
-    788usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlGetWarningsDefaultValue)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlKeepBlanksDefaultValue as *const _ as usize
-    },
-    792usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlKeepBlanksDefaultValue)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlLineNumbersDefaultValue as *const _ as usize
-    },
-    796usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlLineNumbersDefaultValue)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlLoadExtDtdDefaultValue as *const _ as usize
-    },
-    800usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlLoadExtDtdDefaultValue)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlParserDebugEntities as *const _ as usize
-    },
-    804usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlParserDebugEntities)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlPedanticParserDefaultValue as *const _ as usize
-    },
-    808usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlPedanticParserDefaultValue)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlSaveNoEmptyTags as *const _ as usize },
-    812usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlSaveNoEmptyTags)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlIndentTreeOutput as *const _ as usize },
-    816usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlIndentTreeOutput)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlTreeIndentString as *const _ as usize },
-    824usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlTreeIndentString)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlRegisterNodeDefaultValue as *const _ as usize
-    },
-    832usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlRegisterNodeDefaultValue)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlDeregisterNodeDefaultValue as *const _ as usize
-    },
-    840usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlDeregisterNodeDefaultValue)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlMallocAtomic as *const _ as usize },
-    848usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlMallocAtomic)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlLastError as *const _ as usize },
-    856usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlLastError)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlParserInputBufferCreateFilenameValue
-        as *const _ as usize
-    },
-    944usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlParserInputBufferCreateFilenameValue)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlOutputBufferCreateFilenameValue as *const _
-        as usize
-    },
-    952usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlOutputBufferCreateFilenameValue)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlGlobalState>())).xmlStructuredErrorContext as *const _ as usize
-    },
-    960usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlGlobalState),
-      "::",
-      stringify!(xmlStructuredErrorContext)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlParserVersion as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlParserVersion)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlDefaultSAXLocator as *const _ as usize
+  //   },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlDefaultSAXLocator)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlDefaultSAXHandler as *const _ as usize
+  //   },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlDefaultSAXHandler)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).docbDefaultSAXHandler as *const _ as usize
+  //   },
+  //   264usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(docbDefaultSAXHandler)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).htmlDefaultSAXHandler as *const _ as usize
+  //   },
+  //   488usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(htmlDefaultSAXHandler)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlFree as *const _ as usize },
+  //   712usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlFree)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlMalloc as *const _ as usize },
+  //   720usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlMalloc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlMemStrdup as *const _ as usize },
+  //   728usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlMemStrdup)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlRealloc as *const _ as usize },
+  //   736usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlRealloc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlGenericError as *const _ as usize },
+  //   744usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlGenericError)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlStructuredError as *const _ as usize },
+  //   752usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlStructuredError)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlGenericErrorContext as *const _ as usize
+  //   },
+  //   760usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlGenericErrorContext)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).oldXMLWDcompatibility as *const _ as usize
+  //   },
+  //   768usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(oldXMLWDcompatibility)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlBufferAllocScheme as *const _ as usize
+  //   },
+  //   772usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlBufferAllocScheme)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlDefaultBufferSize as *const _ as usize
+  //   },
+  //   776usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlDefaultBufferSize)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlSubstituteEntitiesDefaultValue as *const _
+  //       as usize
+  //   },
+  //   780usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlSubstituteEntitiesDefaultValue)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlDoValidityCheckingDefaultValue as *const _
+  //       as usize
+  //   },
+  //   784usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlDoValidityCheckingDefaultValue)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlGetWarningsDefaultValue as *const _ as usize
+  //   },
+  //   788usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlGetWarningsDefaultValue)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlKeepBlanksDefaultValue as *const _ as usize
+  //   },
+  //   792usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlKeepBlanksDefaultValue)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlLineNumbersDefaultValue as *const _ as usize
+  //   },
+  //   796usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlLineNumbersDefaultValue)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlLoadExtDtdDefaultValue as *const _ as usize
+  //   },
+  //   800usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlLoadExtDtdDefaultValue)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlParserDebugEntities as *const _ as usize
+  //   },
+  //   804usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlParserDebugEntities)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlPedanticParserDefaultValue as *const _ as usize
+  //   },
+  //   808usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlPedanticParserDefaultValue)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlSaveNoEmptyTags as *const _ as usize },
+  //   812usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlSaveNoEmptyTags)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlIndentTreeOutput as *const _ as usize },
+  //   816usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlIndentTreeOutput)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlTreeIndentString as *const _ as usize },
+  //   824usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlTreeIndentString)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlRegisterNodeDefaultValue as *const _ as usize
+  //   },
+  //   832usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlRegisterNodeDefaultValue)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlDeregisterNodeDefaultValue as *const _ as usize
+  //   },
+  //   840usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlDeregisterNodeDefaultValue)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlMallocAtomic as *const _ as usize },
+  //   848usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlMallocAtomic)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlGlobalState>())).xmlLastError as *const _ as usize },
+  //   856usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlLastError)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlParserInputBufferCreateFilenameValue
+  //       as *const _ as usize
+  //   },
+  //   944usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlParserInputBufferCreateFilenameValue)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlOutputBufferCreateFilenameValue as *const _
+  //       as usize
+  //   },
+  //   952usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlOutputBufferCreateFilenameValue)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlGlobalState>())).xmlStructuredErrorContext as *const _ as usize
+  //   },
+  //   960usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlGlobalState),
+  //     "::",
+  //     stringify!(xmlStructuredErrorContext)
+  //   )
+  // );
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -11671,86 +11671,86 @@ fn bindgen_test_layout__xmlOutputBuffer() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlOutputBuffer))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlOutputBuffer>())).context as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlOutputBuffer),
-      "::",
-      stringify!(context)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlOutputBuffer>())).writecallback as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlOutputBuffer),
-      "::",
-      stringify!(writecallback)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlOutputBuffer>())).closecallback as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlOutputBuffer),
-      "::",
-      stringify!(closecallback)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlOutputBuffer>())).encoder as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlOutputBuffer),
-      "::",
-      stringify!(encoder)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlOutputBuffer>())).buffer as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlOutputBuffer),
-      "::",
-      stringify!(buffer)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlOutputBuffer>())).conv as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlOutputBuffer),
-      "::",
-      stringify!(conv)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlOutputBuffer>())).written as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlOutputBuffer),
-      "::",
-      stringify!(written)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlOutputBuffer>())).error as *const _ as usize },
-    52usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlOutputBuffer),
-      "::",
-      stringify!(error)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlOutputBuffer>())).context as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlOutputBuffer),
+  //     "::",
+  //     stringify!(context)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlOutputBuffer>())).writecallback as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlOutputBuffer),
+  //     "::",
+  //     stringify!(writecallback)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlOutputBuffer>())).closecallback as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlOutputBuffer),
+  //     "::",
+  //     stringify!(closecallback)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlOutputBuffer>())).encoder as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlOutputBuffer),
+  //     "::",
+  //     stringify!(encoder)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlOutputBuffer>())).buffer as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlOutputBuffer),
+  //     "::",
+  //     stringify!(buffer)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlOutputBuffer>())).conv as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlOutputBuffer),
+  //     "::",
+  //     stringify!(conv)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlOutputBuffer>())).written as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlOutputBuffer),
+  //     "::",
+  //     stringify!(written)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlOutputBuffer>())).error as *const _ as usize },
+  //   52usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlOutputBuffer),
+  //     "::",
+  //     stringify!(error)
+  //   )
+  // );
 }
 extern "C" {
   pub fn xmlCleanupInputCallbacks();
@@ -12532,146 +12532,146 @@ fn bindgen_test_layout__htmlElemDesc() {
     8usize,
     concat!("Alignment of ", stringify!(_htmlElemDesc))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).name as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlElemDesc),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).startTag as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlElemDesc),
-      "::",
-      stringify!(startTag)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).endTag as *const _ as usize },
-    9usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlElemDesc),
-      "::",
-      stringify!(endTag)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).saveEndTag as *const _ as usize },
-    10usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlElemDesc),
-      "::",
-      stringify!(saveEndTag)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).empty as *const _ as usize },
-    11usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlElemDesc),
-      "::",
-      stringify!(empty)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).depr as *const _ as usize },
-    12usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlElemDesc),
-      "::",
-      stringify!(depr)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).dtd as *const _ as usize },
-    13usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlElemDesc),
-      "::",
-      stringify!(dtd)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).isinline as *const _ as usize },
-    14usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlElemDesc),
-      "::",
-      stringify!(isinline)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).desc as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlElemDesc),
-      "::",
-      stringify!(desc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).subelts as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlElemDesc),
-      "::",
-      stringify!(subelts)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).defaultsubelt as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlElemDesc),
-      "::",
-      stringify!(defaultsubelt)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).attrs_opt as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlElemDesc),
-      "::",
-      stringify!(attrs_opt)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).attrs_depr as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlElemDesc),
-      "::",
-      stringify!(attrs_depr)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).attrs_req as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlElemDesc),
-      "::",
-      stringify!(attrs_req)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).name as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlElemDesc),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).startTag as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlElemDesc),
+  //     "::",
+  //     stringify!(startTag)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).endTag as *const _ as usize },
+  //   9usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlElemDesc),
+  //     "::",
+  //     stringify!(endTag)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).saveEndTag as *const _ as usize },
+  //   10usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlElemDesc),
+  //     "::",
+  //     stringify!(saveEndTag)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).empty as *const _ as usize },
+  //   11usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlElemDesc),
+  //     "::",
+  //     stringify!(empty)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).depr as *const _ as usize },
+  //   12usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlElemDesc),
+  //     "::",
+  //     stringify!(depr)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).dtd as *const _ as usize },
+  //   13usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlElemDesc),
+  //     "::",
+  //     stringify!(dtd)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).isinline as *const _ as usize },
+  //   14usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlElemDesc),
+  //     "::",
+  //     stringify!(isinline)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).desc as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlElemDesc),
+  //     "::",
+  //     stringify!(desc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).subelts as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlElemDesc),
+  //     "::",
+  //     stringify!(subelts)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).defaultsubelt as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlElemDesc),
+  //     "::",
+  //     stringify!(defaultsubelt)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).attrs_opt as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlElemDesc),
+  //     "::",
+  //     stringify!(attrs_opt)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).attrs_depr as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlElemDesc),
+  //     "::",
+  //     stringify!(attrs_depr)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlElemDesc>())).attrs_req as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlElemDesc),
+  //     "::",
+  //     stringify!(attrs_req)
+  //   )
+  // );
 }
 pub type htmlEntityDesc = _htmlEntityDesc;
 pub type htmlEntityDescPtr = *mut htmlEntityDesc;
@@ -12694,36 +12694,36 @@ fn bindgen_test_layout__htmlEntityDesc() {
     8usize,
     concat!("Alignment of ", stringify!(_htmlEntityDesc))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlEntityDesc>())).value as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlEntityDesc),
-      "::",
-      stringify!(value)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlEntityDesc>())).name as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlEntityDesc),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_htmlEntityDesc>())).desc as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_htmlEntityDesc),
-      "::",
-      stringify!(desc)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlEntityDesc>())).value as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlEntityDesc),
+  //     "::",
+  //     stringify!(value)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlEntityDesc>())).name as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlEntityDesc),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_htmlEntityDesc>())).desc as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_htmlEntityDesc),
+  //     "::",
+  //     stringify!(desc)
+  //   )
+  // );
 }
 extern "C" {
   pub fn htmlTagLookup(tag: *const xmlChar) -> *const htmlElemDesc;
@@ -12996,26 +12996,26 @@ fn bindgen_test_layout__xmlChSRange() {
     2usize,
     concat!("Alignment of ", stringify!(_xmlChSRange))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlChSRange>())).low as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlChSRange),
-      "::",
-      stringify!(low)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlChSRange>())).high as *const _ as usize },
-    2usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlChSRange),
-      "::",
-      stringify!(high)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlChSRange>())).low as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlChSRange),
+  //     "::",
+  //     stringify!(low)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlChSRange>())).high as *const _ as usize },
+  //   2usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlChSRange),
+  //     "::",
+  //     stringify!(high)
+  //   )
+  // );
 }
 pub type xmlChLRange = _xmlChLRange;
 pub type xmlChLRangePtr = *mut xmlChLRange;
@@ -13037,26 +13037,26 @@ fn bindgen_test_layout__xmlChLRange() {
     4usize,
     concat!("Alignment of ", stringify!(_xmlChLRange))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlChLRange>())).low as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlChLRange),
-      "::",
-      stringify!(low)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlChLRange>())).high as *const _ as usize },
-    4usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlChLRange),
-      "::",
-      stringify!(high)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlChLRange>())).low as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlChLRange),
+  //     "::",
+  //     stringify!(low)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlChLRange>())).high as *const _ as usize },
+  //   4usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlChLRange),
+  //     "::",
+  //     stringify!(high)
+  //   )
+  // );
 }
 pub type xmlChRangeGroup = _xmlChRangeGroup;
 pub type xmlChRangeGroupPtr = *mut xmlChRangeGroup;
@@ -13080,46 +13080,46 @@ fn bindgen_test_layout__xmlChRangeGroup() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlChRangeGroup))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlChRangeGroup>())).nbShortRange as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlChRangeGroup),
-      "::",
-      stringify!(nbShortRange)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlChRangeGroup>())).nbLongRange as *const _ as usize },
-    4usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlChRangeGroup),
-      "::",
-      stringify!(nbLongRange)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlChRangeGroup>())).shortRange as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlChRangeGroup),
-      "::",
-      stringify!(shortRange)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlChRangeGroup>())).longRange as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlChRangeGroup),
-      "::",
-      stringify!(longRange)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlChRangeGroup>())).nbShortRange as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlChRangeGroup),
+  //     "::",
+  //     stringify!(nbShortRange)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlChRangeGroup>())).nbLongRange as *const _ as usize },
+  //   4usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlChRangeGroup),
+  //     "::",
+  //     stringify!(nbLongRange)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlChRangeGroup>())).shortRange as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlChRangeGroup),
+  //     "::",
+  //     stringify!(shortRange)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlChRangeGroup>())).longRange as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlChRangeGroup),
+  //     "::",
+  //     stringify!(longRange)
+  //   )
+  // );
 }
 extern "C" {
   /// Range checking routine
@@ -13797,36 +13797,36 @@ fn bindgen_test_layout__xmlNodeSet() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlNodeSet))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNodeSet>())).nodeNr as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNodeSet),
-      "::",
-      stringify!(nodeNr)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNodeSet>())).nodeMax as *const _ as usize },
-    4usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNodeSet),
-      "::",
-      stringify!(nodeMax)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlNodeSet>())).nodeTab as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlNodeSet),
-      "::",
-      stringify!(nodeTab)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNodeSet>())).nodeNr as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNodeSet),
+  //     "::",
+  //     stringify!(nodeNr)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNodeSet>())).nodeMax as *const _ as usize },
+  //   4usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNodeSet),
+  //     "::",
+  //     stringify!(nodeMax)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlNodeSet>())).nodeTab as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlNodeSet),
+  //     "::",
+  //     stringify!(nodeTab)
+  //   )
+  // );
 }
 pub const xmlXPathObjectType_XPATH_UNDEFINED: xmlXPathObjectType = 0;
 pub const xmlXPathObjectType_XPATH_NODESET: xmlXPathObjectType = 1;
@@ -13866,96 +13866,96 @@ fn bindgen_test_layout__xmlXPathObject() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlXPathObject))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).type_ as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathObject),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).nodesetval as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathObject),
-      "::",
-      stringify!(nodesetval)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).boolval as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathObject),
-      "::",
-      stringify!(boolval)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).floatval as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathObject),
-      "::",
-      stringify!(floatval)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).stringval as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathObject),
-      "::",
-      stringify!(stringval)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).user as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathObject),
-      "::",
-      stringify!(user)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).index as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathObject),
-      "::",
-      stringify!(index)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).user2 as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathObject),
-      "::",
-      stringify!(user2)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).index2 as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathObject),
-      "::",
-      stringify!(index2)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).type_ as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathObject),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).nodesetval as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathObject),
+  //     "::",
+  //     stringify!(nodesetval)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).boolval as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathObject),
+  //     "::",
+  //     stringify!(boolval)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).floatval as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathObject),
+  //     "::",
+  //     stringify!(floatval)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).stringval as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathObject),
+  //     "::",
+  //     stringify!(stringval)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).user as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathObject),
+  //     "::",
+  //     stringify!(user)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).index as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathObject),
+  //     "::",
+  //     stringify!(index)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).user2 as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathObject),
+  //     "::",
+  //     stringify!(user2)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathObject>())).index2 as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathObject),
+  //     "::",
+  //     stringify!(index2)
+  //   )
+  // );
 }
 /// xmlXPathConvertFunc:
 /// @obj:  an XPath object
@@ -13991,26 +13991,26 @@ fn bindgen_test_layout__xmlXPathType() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlXPathType))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathType>())).name as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathType),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathType>())).func as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathType),
-      "::",
-      stringify!(func)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathType>())).name as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathType),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathType>())).func as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathType),
+  //     "::",
+  //     stringify!(func)
+  //   )
+  // );
 }
 pub type xmlXPathVariable = _xmlXPathVariable;
 pub type xmlXPathVariablePtr = *mut xmlXPathVariable;
@@ -14032,26 +14032,26 @@ fn bindgen_test_layout__xmlXPathVariable() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlXPathVariable))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathVariable>())).name as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathVariable),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathVariable>())).value as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathVariable),
-      "::",
-      stringify!(value)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathVariable>())).name as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathVariable),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathVariable>())).value as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathVariable),
+  //     "::",
+  //     stringify!(value)
+  //   )
+  // );
 }
 /// xmlXPathEvalFunc:
 /// @ctxt: an XPath parser context
@@ -14081,26 +14081,26 @@ fn bindgen_test_layout__xmlXPathFunct() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlXPathFunct))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathFunct>())).name as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathFunct),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathFunct>())).func as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathFunct),
-      "::",
-      stringify!(func)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathFunct>())).name as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathFunct),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathFunct>())).func as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathFunct),
+  //     "::",
+  //     stringify!(func)
+  //   )
+  // );
 }
 /// xmlXPathAxisFunc:
 /// @ctxt:  the XPath interpreter context
@@ -14134,26 +14134,26 @@ fn bindgen_test_layout__xmlXPathAxis() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlXPathAxis))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathAxis>())).name as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathAxis),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathAxis>())).func as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathAxis),
-      "::",
-      stringify!(func)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathAxis>())).name as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathAxis),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathAxis>())).func as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathAxis),
+  //     "::",
+  //     stringify!(func)
+  //   )
+  // );
 }
 /// xmlXPathFunction:
 /// @ctxt:  the XPath interprestation context
@@ -14266,400 +14266,400 @@ fn bindgen_test_layout__xmlXPathContext() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlXPathContext))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).doc as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(doc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).node as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(node)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlXPathContext>())).nb_variables_unused as *const _ as usize
-    },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(nb_variables_unused)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlXPathContext>())).max_variables_unused as *const _ as usize
-    },
-    20usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(max_variables_unused)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).varHash as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(varHash)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).nb_types as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(nb_types)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).max_types as *const _ as usize },
-    36usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(max_types)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).types as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(types)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).nb_funcs_unused as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(nb_funcs_unused)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).max_funcs_unused as *const _ as usize },
-    52usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(max_funcs_unused)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).funcHash as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(funcHash)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).nb_axis as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(nb_axis)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).max_axis as *const _ as usize },
-    68usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(max_axis)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).axis as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(axis)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).namespaces as *const _ as usize },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(namespaces)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).nsNr as *const _ as usize },
-    88usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(nsNr)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).user as *const _ as usize },
-    96usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(user)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).contextSize as *const _ as usize },
-    104usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(contextSize)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).proximityPosition as *const _ as usize },
-    108usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(proximityPosition)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).xptr as *const _ as usize },
-    112usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(xptr)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).here as *const _ as usize },
-    120usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(here)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).origin as *const _ as usize },
-    128usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(origin)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).nsHash as *const _ as usize },
-    136usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(nsHash)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).varLookupFunc as *const _ as usize },
-    144usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(varLookupFunc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).varLookupData as *const _ as usize },
-    152usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(varLookupData)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).extra as *const _ as usize },
-    160usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(extra)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).function as *const _ as usize },
-    168usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(function)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).functionURI as *const _ as usize },
-    176usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(functionURI)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).funcLookupFunc as *const _ as usize },
-    184usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(funcLookupFunc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).funcLookupData as *const _ as usize },
-    192usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(funcLookupData)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).tmpNsList as *const _ as usize },
-    200usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(tmpNsList)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).tmpNsNr as *const _ as usize },
-    208usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(tmpNsNr)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).userData as *const _ as usize },
-    216usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(userData)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).error as *const _ as usize },
-    224usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(error)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).lastError as *const _ as usize },
-    232usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(lastError)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).debugNode as *const _ as usize },
-    320usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(debugNode)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).dict as *const _ as usize },
-    328usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(dict)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).flags as *const _ as usize },
-    336usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(flags)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).cache as *const _ as usize },
-    344usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathContext),
-      "::",
-      stringify!(cache)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).doc as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(doc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).node as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(node)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlXPathContext>())).nb_variables_unused as *const _ as usize
+  //   },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(nb_variables_unused)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlXPathContext>())).max_variables_unused as *const _ as usize
+  //   },
+  //   20usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(max_variables_unused)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).varHash as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(varHash)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).nb_types as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(nb_types)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).max_types as *const _ as usize },
+  //   36usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(max_types)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).types as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(types)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).nb_funcs_unused as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(nb_funcs_unused)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).max_funcs_unused as *const _ as usize },
+  //   52usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(max_funcs_unused)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).funcHash as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(funcHash)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).nb_axis as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(nb_axis)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).max_axis as *const _ as usize },
+  //   68usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(max_axis)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).axis as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(axis)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).namespaces as *const _ as usize },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(namespaces)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).nsNr as *const _ as usize },
+  //   88usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(nsNr)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).user as *const _ as usize },
+  //   96usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(user)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).contextSize as *const _ as usize },
+  //   104usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(contextSize)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).proximityPosition as *const _ as usize },
+  //   108usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(proximityPosition)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).xptr as *const _ as usize },
+  //   112usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(xptr)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).here as *const _ as usize },
+  //   120usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(here)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).origin as *const _ as usize },
+  //   128usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(origin)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).nsHash as *const _ as usize },
+  //   136usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(nsHash)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).varLookupFunc as *const _ as usize },
+  //   144usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(varLookupFunc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).varLookupData as *const _ as usize },
+  //   152usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(varLookupData)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).extra as *const _ as usize },
+  //   160usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(extra)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).function as *const _ as usize },
+  //   168usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(function)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).functionURI as *const _ as usize },
+  //   176usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(functionURI)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).funcLookupFunc as *const _ as usize },
+  //   184usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(funcLookupFunc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).funcLookupData as *const _ as usize },
+  //   192usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(funcLookupData)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).tmpNsList as *const _ as usize },
+  //   200usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(tmpNsList)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).tmpNsNr as *const _ as usize },
+  //   208usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(tmpNsNr)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).userData as *const _ as usize },
+  //   216usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(userData)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).error as *const _ as usize },
+  //   224usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(error)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).lastError as *const _ as usize },
+  //   232usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(lastError)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).debugNode as *const _ as usize },
+  //   320usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(debugNode)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).dict as *const _ as usize },
+  //   328usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(dict)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).flags as *const _ as usize },
+  //   336usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(flags)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathContext>())).cache as *const _ as usize },
+  //   344usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathContext),
+  //     "::",
+  //     stringify!(cache)
+  //   )
+  // );
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -14700,126 +14700,126 @@ fn bindgen_test_layout__xmlXPathParserContext() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlXPathParserContext))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).cur as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathParserContext),
-      "::",
-      stringify!(cur)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).base as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathParserContext),
-      "::",
-      stringify!(base)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).error as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathParserContext),
-      "::",
-      stringify!(error)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).context as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathParserContext),
-      "::",
-      stringify!(context)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).value as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathParserContext),
-      "::",
-      stringify!(value)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).valueNr as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathParserContext),
-      "::",
-      stringify!(valueNr)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).valueMax as *const _ as usize },
-    44usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathParserContext),
-      "::",
-      stringify!(valueMax)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).valueTab as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathParserContext),
-      "::",
-      stringify!(valueTab)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).comp as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathParserContext),
-      "::",
-      stringify!(comp)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).xptr as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathParserContext),
-      "::",
-      stringify!(xptr)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).ancestor as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathParserContext),
-      "::",
-      stringify!(ancestor)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).valueFrame as *const _ as usize },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlXPathParserContext),
-      "::",
-      stringify!(valueFrame)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).cur as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathParserContext),
+  //     "::",
+  //     stringify!(cur)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).base as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathParserContext),
+  //     "::",
+  //     stringify!(base)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).error as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathParserContext),
+  //     "::",
+  //     stringify!(error)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).context as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathParserContext),
+  //     "::",
+  //     stringify!(context)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).value as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathParserContext),
+  //     "::",
+  //     stringify!(value)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).valueNr as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathParserContext),
+  //     "::",
+  //     stringify!(valueNr)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).valueMax as *const _ as usize },
+  //   44usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathParserContext),
+  //     "::",
+  //     stringify!(valueMax)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).valueTab as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathParserContext),
+  //     "::",
+  //     stringify!(valueTab)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).comp as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathParserContext),
+  //     "::",
+  //     stringify!(comp)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).xptr as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathParserContext),
+  //     "::",
+  //     stringify!(xptr)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).ancestor as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathParserContext),
+  //     "::",
+  //     stringify!(ancestor)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlXPathParserContext>())).valueFrame as *const _ as usize },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlXPathParserContext),
+  //     "::",
+  //     stringify!(valueFrame)
+  //   )
+  // );
 }
 extern "C" {
   #[link_name = "\u{1}xmlXPathNAN"]
@@ -15274,76 +15274,76 @@ fn bindgen_test_layout__xmlShellCtxt() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlShellCtxt))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlShellCtxt>())).filename as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlShellCtxt),
-      "::",
-      stringify!(filename)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlShellCtxt>())).doc as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlShellCtxt),
-      "::",
-      stringify!(doc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlShellCtxt>())).node as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlShellCtxt),
-      "::",
-      stringify!(node)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlShellCtxt>())).pctxt as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlShellCtxt),
-      "::",
-      stringify!(pctxt)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlShellCtxt>())).loaded as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlShellCtxt),
-      "::",
-      stringify!(loaded)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlShellCtxt>())).output as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlShellCtxt),
-      "::",
-      stringify!(output)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlShellCtxt>())).input as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlShellCtxt),
-      "::",
-      stringify!(input)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlShellCtxt>())).filename as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlShellCtxt),
+  //     "::",
+  //     stringify!(filename)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlShellCtxt>())).doc as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlShellCtxt),
+  //     "::",
+  //     stringify!(doc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlShellCtxt>())).node as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlShellCtxt),
+  //     "::",
+  //     stringify!(node)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlShellCtxt>())).pctxt as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlShellCtxt),
+  //     "::",
+  //     stringify!(pctxt)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlShellCtxt>())).loaded as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlShellCtxt),
+  //     "::",
+  //     stringify!(loaded)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlShellCtxt>())).output as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlShellCtxt),
+  //     "::",
+  //     stringify!(output)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlShellCtxt>())).input as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlShellCtxt),
+  //     "::",
+  //     stringify!(input)
+  //   )
+  // );
 }
 /// xmlShellCmd:
 /// @ctxt:  a shell context
@@ -16122,26 +16122,26 @@ fn bindgen_test_layout__xmlSchemaAnnot() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlSchemaAnnot))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAnnot>())).next as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAnnot),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAnnot>())).content as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAnnot),
-      "::",
-      stringify!(content)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAnnot>())).next as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAnnot),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAnnot>())).content as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAnnot),
+  //     "::",
+  //     stringify!(content)
+  //   )
+  // );
 }
 /// xmlSchemaAttribute:
 /// An attribute definition.
@@ -16182,196 +16182,196 @@ fn bindgen_test_layout__xmlSchemaAttribute() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlSchemaAttribute))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).type_ as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).next as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).name as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).id as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(id)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).ref_ as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(ref_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).refNs as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(refNs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).typeName as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(typeName)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).typeNs as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(typeNs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).annot as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(annot)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).base as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(base)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).occurs as *const _ as usize },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(occurs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).defValue as *const _ as usize },
-    88usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(defValue)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).subtypes as *const _ as usize },
-    96usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(subtypes)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).node as *const _ as usize },
-    104usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(node)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).targetNamespace as *const _ as usize },
-    112usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(targetNamespace)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).flags as *const _ as usize },
-    120usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(flags)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).refPrefix as *const _ as usize },
-    128usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(refPrefix)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).defVal as *const _ as usize },
-    136usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(defVal)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).refDecl as *const _ as usize },
-    144usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttribute),
-      "::",
-      stringify!(refDecl)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).type_ as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).next as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).name as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).id as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(id)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).ref_ as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(ref_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).refNs as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(refNs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).typeName as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(typeName)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).typeNs as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(typeNs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).annot as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(annot)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).base as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(base)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).occurs as *const _ as usize },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(occurs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).defValue as *const _ as usize },
+  //   88usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(defValue)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).subtypes as *const _ as usize },
+  //   96usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(subtypes)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).node as *const _ as usize },
+  //   104usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(node)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).targetNamespace as *const _ as usize },
+  //   112usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(targetNamespace)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).flags as *const _ as usize },
+  //   120usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(flags)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).refPrefix as *const _ as usize },
+  //   128usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(refPrefix)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).defVal as *const _ as usize },
+  //   136usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(defVal)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttribute>())).refDecl as *const _ as usize },
+  //   144usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttribute),
+  //     "::",
+  //     stringify!(refDecl)
+  //   )
+  // );
 }
 /// xmlSchemaAttributeLink:
 /// Used to build a list of attribute uses on complexType definitions.
@@ -16396,26 +16396,26 @@ fn bindgen_test_layout__xmlSchemaAttributeLink() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlSchemaAttributeLink))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeLink>())).next as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeLink),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeLink>())).attr as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeLink),
-      "::",
-      stringify!(attr)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeLink>())).next as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeLink),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeLink>())).attr as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeLink),
+  //     "::",
+  //     stringify!(attr)
+  //   )
+  // );
 }
 /// xmlSchemaCharValueLink:
 /// Used to build a list of namespaces on wildcards.
@@ -16439,26 +16439,26 @@ fn bindgen_test_layout__xmlSchemaWildcardNs() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlSchemaWildcardNs))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcardNs>())).next as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaWildcardNs),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcardNs>())).value as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaWildcardNs),
-      "::",
-      stringify!(value)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcardNs>())).next as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaWildcardNs),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcardNs>())).value as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaWildcardNs),
+  //     "::",
+  //     stringify!(value)
+  //   )
+  // );
 }
 /// xmlSchemaWildcard.
 /// A wildcard.
@@ -16491,116 +16491,116 @@ fn bindgen_test_layout__xmlSchemaWildcard() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlSchemaWildcard))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).type_ as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaWildcard),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).id as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaWildcard),
-      "::",
-      stringify!(id)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).annot as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaWildcard),
-      "::",
-      stringify!(annot)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).node as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaWildcard),
-      "::",
-      stringify!(node)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).minOccurs as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaWildcard),
-      "::",
-      stringify!(minOccurs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).maxOccurs as *const _ as usize },
-    36usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaWildcard),
-      "::",
-      stringify!(maxOccurs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).processContents as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaWildcard),
-      "::",
-      stringify!(processContents)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).any as *const _ as usize },
-    44usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaWildcard),
-      "::",
-      stringify!(any)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).nsSet as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaWildcard),
-      "::",
-      stringify!(nsSet)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).negNsSet as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaWildcard),
-      "::",
-      stringify!(negNsSet)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).flags as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaWildcard),
-      "::",
-      stringify!(flags)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).type_ as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaWildcard),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).id as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaWildcard),
+  //     "::",
+  //     stringify!(id)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).annot as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaWildcard),
+  //     "::",
+  //     stringify!(annot)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).node as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaWildcard),
+  //     "::",
+  //     stringify!(node)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).minOccurs as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaWildcard),
+  //     "::",
+  //     stringify!(minOccurs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).maxOccurs as *const _ as usize },
+  //   36usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaWildcard),
+  //     "::",
+  //     stringify!(maxOccurs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).processContents as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaWildcard),
+  //     "::",
+  //     stringify!(processContents)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).any as *const _ as usize },
+  //   44usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaWildcard),
+  //     "::",
+  //     stringify!(any)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).nsSet as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaWildcard),
+  //     "::",
+  //     stringify!(nsSet)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).negNsSet as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaWildcard),
+  //     "::",
+  //     stringify!(negNsSet)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaWildcard>())).flags as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaWildcard),
+  //     "::",
+  //     stringify!(flags)
+  //   )
+  // );
 }
 /// An attribute group definition.
 ///
@@ -16639,160 +16639,160 @@ fn bindgen_test_layout__xmlSchemaAttributeGroup() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlSchemaAttributeGroup))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).type_ as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeGroup),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).next as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeGroup),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).name as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeGroup),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).id as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeGroup),
-      "::",
-      stringify!(id)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).ref_ as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeGroup),
-      "::",
-      stringify!(ref_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).refNs as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeGroup),
-      "::",
-      stringify!(refNs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).annot as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeGroup),
-      "::",
-      stringify!(annot)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).attributes as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeGroup),
-      "::",
-      stringify!(attributes)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).node as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeGroup),
-      "::",
-      stringify!(node)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).flags as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeGroup),
-      "::",
-      stringify!(flags)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).attributeWildcard as *const _ as usize
-    },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeGroup),
-      "::",
-      stringify!(attributeWildcard)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).refPrefix as *const _ as usize },
-    88usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeGroup),
-      "::",
-      stringify!(refPrefix)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).refItem as *const _ as usize },
-    96usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeGroup),
-      "::",
-      stringify!(refItem)
-    )
-  );
-  assert_eq!(
-    unsafe {
-      &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).targetNamespace as *const _ as usize
-    },
-    104usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeGroup),
-      "::",
-      stringify!(targetNamespace)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).attrUses as *const _ as usize },
-    112usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaAttributeGroup),
-      "::",
-      stringify!(attrUses)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).type_ as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeGroup),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).next as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeGroup),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).name as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeGroup),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).id as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeGroup),
+  //     "::",
+  //     stringify!(id)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).ref_ as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeGroup),
+  //     "::",
+  //     stringify!(ref_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).refNs as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeGroup),
+  //     "::",
+  //     stringify!(refNs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).annot as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeGroup),
+  //     "::",
+  //     stringify!(annot)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).attributes as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeGroup),
+  //     "::",
+  //     stringify!(attributes)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).node as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeGroup),
+  //     "::",
+  //     stringify!(node)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).flags as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeGroup),
+  //     "::",
+  //     stringify!(flags)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).attributeWildcard as *const _ as usize
+  //   },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeGroup),
+  //     "::",
+  //     stringify!(attributeWildcard)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).refPrefix as *const _ as usize },
+  //   88usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeGroup),
+  //     "::",
+  //     stringify!(refPrefix)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).refItem as *const _ as usize },
+  //   96usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeGroup),
+  //     "::",
+  //     stringify!(refItem)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe {
+  //     &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).targetNamespace as *const _ as usize
+  //   },
+  //   104usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeGroup),
+  //     "::",
+  //     stringify!(targetNamespace)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaAttributeGroup>())).attrUses as *const _ as usize },
+  //   112usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaAttributeGroup),
+  //     "::",
+  //     stringify!(attrUses)
+  //   )
+  // );
 }
 /// xmlSchemaTypeLink:
 /// Used to build a list of types (e.g. member types of
@@ -16817,26 +16817,26 @@ fn bindgen_test_layout__xmlSchemaTypeLink() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlSchemaTypeLink))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaTypeLink>())).next as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaTypeLink),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaTypeLink>())).type_ as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaTypeLink),
-      "::",
-      stringify!(type_)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaTypeLink>())).next as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaTypeLink),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaTypeLink>())).type_ as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaTypeLink),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
 }
 /// xmlSchemaFacetLink:
 /// Used to build a list of facets.
@@ -16860,26 +16860,26 @@ fn bindgen_test_layout__xmlSchemaFacetLink() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlSchemaFacetLink))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaFacetLink>())).next as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaFacetLink),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaFacetLink>())).facet as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaFacetLink),
-      "::",
-      stringify!(facet)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaFacetLink>())).next as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaFacetLink),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaFacetLink>())).facet as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaFacetLink),
+  //     "::",
+  //     stringify!(facet)
+  //   )
+  // );
 }
 /// _xmlSchemaType:
 ///
@@ -16930,306 +16930,306 @@ fn bindgen_test_layout__xmlSchemaType() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlSchemaType))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).type_ as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).next as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).name as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).id as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(id)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).ref_ as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(ref_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).refNs as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(refNs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).annot as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(annot)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).subtypes as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(subtypes)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).attributes as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(attributes)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).node as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(node)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).minOccurs as *const _ as usize },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(minOccurs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).maxOccurs as *const _ as usize },
-    84usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(maxOccurs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).flags as *const _ as usize },
-    88usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(flags)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).contentType as *const _ as usize },
-    92usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(contentType)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).base as *const _ as usize },
-    96usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(base)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).baseNs as *const _ as usize },
-    104usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(baseNs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).baseType as *const _ as usize },
-    112usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(baseType)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).facets as *const _ as usize },
-    120usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(facets)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).redef as *const _ as usize },
-    128usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(redef)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).recurse as *const _ as usize },
-    136usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(recurse)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).attributeUses as *const _ as usize },
-    144usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(attributeUses)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).attributeWildcard as *const _ as usize },
-    152usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(attributeWildcard)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).builtInType as *const _ as usize },
-    160usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(builtInType)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).memberTypes as *const _ as usize },
-    168usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(memberTypes)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).facetSet as *const _ as usize },
-    176usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(facetSet)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).refPrefix as *const _ as usize },
-    184usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(refPrefix)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).contentTypeDef as *const _ as usize },
-    192usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(contentTypeDef)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).contModel as *const _ as usize },
-    200usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(contModel)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).targetNamespace as *const _ as usize },
-    208usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(targetNamespace)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).attrUses as *const _ as usize },
-    216usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaType),
-      "::",
-      stringify!(attrUses)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).type_ as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).next as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).name as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).id as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(id)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).ref_ as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(ref_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).refNs as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(refNs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).annot as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(annot)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).subtypes as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(subtypes)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).attributes as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(attributes)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).node as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(node)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).minOccurs as *const _ as usize },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(minOccurs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).maxOccurs as *const _ as usize },
+  //   84usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(maxOccurs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).flags as *const _ as usize },
+  //   88usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(flags)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).contentType as *const _ as usize },
+  //   92usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(contentType)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).base as *const _ as usize },
+  //   96usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(base)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).baseNs as *const _ as usize },
+  //   104usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(baseNs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).baseType as *const _ as usize },
+  //   112usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(baseType)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).facets as *const _ as usize },
+  //   120usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(facets)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).redef as *const _ as usize },
+  //   128usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(redef)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).recurse as *const _ as usize },
+  //   136usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(recurse)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).attributeUses as *const _ as usize },
+  //   144usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(attributeUses)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).attributeWildcard as *const _ as usize },
+  //   152usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(attributeWildcard)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).builtInType as *const _ as usize },
+  //   160usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(builtInType)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).memberTypes as *const _ as usize },
+  //   168usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(memberTypes)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).facetSet as *const _ as usize },
+  //   176usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(facetSet)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).refPrefix as *const _ as usize },
+  //   184usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(refPrefix)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).contentTypeDef as *const _ as usize },
+  //   192usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(contentTypeDef)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).contModel as *const _ as usize },
+  //   200usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(contModel)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).targetNamespace as *const _ as usize },
+  //   208usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(targetNamespace)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaType>())).attrUses as *const _ as usize },
+  //   216usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaType),
+  //     "::",
+  //     stringify!(attrUses)
+  //   )
+  // );
 }
 pub type xmlSchemaElement = _xmlSchemaElement;
 pub type xmlSchemaElementPtr = *mut xmlSchemaElement;
@@ -17275,266 +17275,266 @@ fn bindgen_test_layout__xmlSchemaElement() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlSchemaElement))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).type_ as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).next as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).name as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).id as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(id)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).ref_ as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(ref_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).refNs as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(refNs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).annot as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(annot)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).subtypes as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(subtypes)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).attributes as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(attributes)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).node as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(node)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).minOccurs as *const _ as usize },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(minOccurs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).maxOccurs as *const _ as usize },
-    84usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(maxOccurs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).flags as *const _ as usize },
-    88usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(flags)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).targetNamespace as *const _ as usize },
-    96usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(targetNamespace)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).namedType as *const _ as usize },
-    104usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(namedType)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).namedTypeNs as *const _ as usize },
-    112usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(namedTypeNs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).substGroup as *const _ as usize },
-    120usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(substGroup)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).substGroupNs as *const _ as usize },
-    128usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(substGroupNs)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).scope as *const _ as usize },
-    136usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(scope)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).value as *const _ as usize },
-    144usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(value)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).refDecl as *const _ as usize },
-    152usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(refDecl)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).contModel as *const _ as usize },
-    160usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(contModel)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).contentType as *const _ as usize },
-    168usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(contentType)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).refPrefix as *const _ as usize },
-    176usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(refPrefix)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).defVal as *const _ as usize },
-    184usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(defVal)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).idcs as *const _ as usize },
-    192usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaElement),
-      "::",
-      stringify!(idcs)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).type_ as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).next as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).name as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).id as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(id)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).ref_ as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(ref_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).refNs as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(refNs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).annot as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(annot)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).subtypes as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(subtypes)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).attributes as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(attributes)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).node as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(node)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).minOccurs as *const _ as usize },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(minOccurs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).maxOccurs as *const _ as usize },
+  //   84usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(maxOccurs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).flags as *const _ as usize },
+  //   88usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(flags)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).targetNamespace as *const _ as usize },
+  //   96usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(targetNamespace)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).namedType as *const _ as usize },
+  //   104usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(namedType)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).namedTypeNs as *const _ as usize },
+  //   112usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(namedTypeNs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).substGroup as *const _ as usize },
+  //   120usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(substGroup)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).substGroupNs as *const _ as usize },
+  //   128usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(substGroupNs)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).scope as *const _ as usize },
+  //   136usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(scope)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).value as *const _ as usize },
+  //   144usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(value)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).refDecl as *const _ as usize },
+  //   152usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(refDecl)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).contModel as *const _ as usize },
+  //   160usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(contModel)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).contentType as *const _ as usize },
+  //   168usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(contentType)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).refPrefix as *const _ as usize },
+  //   176usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(refPrefix)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).defVal as *const _ as usize },
+  //   184usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(defVal)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaElement>())).idcs as *const _ as usize },
+  //   192usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaElement),
+  //     "::",
+  //     stringify!(idcs)
+  //   )
+  // );
 }
 /// A facet definition.
 #[repr(C)]
@@ -17563,106 +17563,106 @@ fn bindgen_test_layout__xmlSchemaFacet() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlSchemaFacet))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).type_ as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaFacet),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).next as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaFacet),
-      "::",
-      stringify!(next)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).value as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaFacet),
-      "::",
-      stringify!(value)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).id as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaFacet),
-      "::",
-      stringify!(id)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).annot as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaFacet),
-      "::",
-      stringify!(annot)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).node as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaFacet),
-      "::",
-      stringify!(node)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).fixed as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaFacet),
-      "::",
-      stringify!(fixed)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).whitespace as *const _ as usize },
-    52usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaFacet),
-      "::",
-      stringify!(whitespace)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).val as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaFacet),
-      "::",
-      stringify!(val)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).regexp as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaFacet),
-      "::",
-      stringify!(regexp)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).type_ as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaFacet),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).next as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaFacet),
+  //     "::",
+  //     stringify!(next)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).value as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaFacet),
+  //     "::",
+  //     stringify!(value)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).id as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaFacet),
+  //     "::",
+  //     stringify!(id)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).annot as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaFacet),
+  //     "::",
+  //     stringify!(annot)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).node as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaFacet),
+  //     "::",
+  //     stringify!(node)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).fixed as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaFacet),
+  //     "::",
+  //     stringify!(fixed)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).whitespace as *const _ as usize },
+  //   52usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaFacet),
+  //     "::",
+  //     stringify!(whitespace)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).val as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaFacet),
+  //     "::",
+  //     stringify!(val)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaFacet>())).regexp as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaFacet),
+  //     "::",
+  //     stringify!(regexp)
+  //   )
+  // );
 }
 /// A notation definition.
 pub type xmlSchemaNotation = _xmlSchemaNotation;
@@ -17688,56 +17688,56 @@ fn bindgen_test_layout__xmlSchemaNotation() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlSchemaNotation))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaNotation>())).type_ as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaNotation),
-      "::",
-      stringify!(type_)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaNotation>())).name as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaNotation),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaNotation>())).annot as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaNotation),
-      "::",
-      stringify!(annot)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaNotation>())).identifier as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaNotation),
-      "::",
-      stringify!(identifier)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchemaNotation>())).targetNamespace as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchemaNotation),
-      "::",
-      stringify!(targetNamespace)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaNotation>())).type_ as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaNotation),
+  //     "::",
+  //     stringify!(type_)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaNotation>())).name as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaNotation),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaNotation>())).annot as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaNotation),
+  //     "::",
+  //     stringify!(annot)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaNotation>())).identifier as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaNotation),
+  //     "::",
+  //     stringify!(identifier)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchemaNotation>())).targetNamespace as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchemaNotation),
+  //     "::",
+  //     stringify!(targetNamespace)
+  //   )
+  // );
 }
 /// _xmlSchema:
 ///
@@ -17779,216 +17779,216 @@ fn bindgen_test_layout__xmlSchema() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlSchema))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).name as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(name)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).targetNamespace as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(targetNamespace)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).version as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(version)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).id as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(id)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).doc as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(doc)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).annot as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(annot)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).flags as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(flags)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).typeDecl as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(typeDecl)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).attrDecl as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(attrDecl)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).attrgrpDecl as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(attrgrpDecl)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).elemDecl as *const _ as usize },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(elemDecl)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).notaDecl as *const _ as usize },
-    88usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(notaDecl)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).schemasImports as *const _ as usize },
-    96usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(schemasImports)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>()))._private as *const _ as usize },
-    104usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(_private)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).groupDecl as *const _ as usize },
-    112usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(groupDecl)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).dict as *const _ as usize },
-    120usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(dict)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).includes as *const _ as usize },
-    128usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(includes)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).preserve as *const _ as usize },
-    136usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(preserve)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).counter as *const _ as usize },
-    140usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(counter)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).idcDef as *const _ as usize },
-    144usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(idcDef)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlSchema>())).volatiles as *const _ as usize },
-    152usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlSchema),
-      "::",
-      stringify!(volatiles)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).name as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(name)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).targetNamespace as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(targetNamespace)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).version as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(version)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).id as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(id)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).doc as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(doc)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).annot as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(annot)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).flags as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(flags)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).typeDecl as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(typeDecl)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).attrDecl as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(attrDecl)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).attrgrpDecl as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(attrgrpDecl)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).elemDecl as *const _ as usize },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(elemDecl)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).notaDecl as *const _ as usize },
+  //   88usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(notaDecl)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).schemasImports as *const _ as usize },
+  //   96usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(schemasImports)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>()))._private as *const _ as usize },
+  //   104usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(_private)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).groupDecl as *const _ as usize },
+  //   112usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(groupDecl)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).dict as *const _ as usize },
+  //   120usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(dict)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).includes as *const _ as usize },
+  //   128usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(includes)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).preserve as *const _ as usize },
+  //   136usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(preserve)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).counter as *const _ as usize },
+  //   140usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(counter)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).idcDef as *const _ as usize },
+  //   144usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(idcDef)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlSchema>())).volatiles as *const _ as usize },
+  //   152usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlSchema),
+  //     "::",
+  //     stringify!(volatiles)
+  //   )
+  // );
 }
 extern "C" {
   pub fn xmlSchemaFreeType(type_: xmlSchemaTypePtr);
@@ -18157,116 +18157,116 @@ fn bindgen_test_layout__xmlURI() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlURI))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlURI>())).scheme as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlURI),
-      "::",
-      stringify!(scheme)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlURI>())).opaque as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlURI),
-      "::",
-      stringify!(opaque)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlURI>())).authority as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlURI),
-      "::",
-      stringify!(authority)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlURI>())).server as *const _ as usize },
-    24usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlURI),
-      "::",
-      stringify!(server)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlURI>())).user as *const _ as usize },
-    32usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlURI),
-      "::",
-      stringify!(user)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlURI>())).port as *const _ as usize },
-    40usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlURI),
-      "::",
-      stringify!(port)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlURI>())).path as *const _ as usize },
-    48usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlURI),
-      "::",
-      stringify!(path)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlURI>())).query as *const _ as usize },
-    56usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlURI),
-      "::",
-      stringify!(query)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlURI>())).fragment as *const _ as usize },
-    64usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlURI),
-      "::",
-      stringify!(fragment)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlURI>())).cleanup as *const _ as usize },
-    72usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlURI),
-      "::",
-      stringify!(cleanup)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlURI>())).query_raw as *const _ as usize },
-    80usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlURI),
-      "::",
-      stringify!(query_raw)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlURI>())).scheme as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlURI),
+  //     "::",
+  //     stringify!(scheme)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlURI>())).opaque as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlURI),
+  //     "::",
+  //     stringify!(opaque)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlURI>())).authority as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlURI),
+  //     "::",
+  //     stringify!(authority)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlURI>())).server as *const _ as usize },
+  //   24usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlURI),
+  //     "::",
+  //     stringify!(server)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlURI>())).user as *const _ as usize },
+  //   32usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlURI),
+  //     "::",
+  //     stringify!(user)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlURI>())).port as *const _ as usize },
+  //   40usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlURI),
+  //     "::",
+  //     stringify!(port)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlURI>())).path as *const _ as usize },
+  //   48usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlURI),
+  //     "::",
+  //     stringify!(path)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlURI>())).query as *const _ as usize },
+  //   56usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlURI),
+  //     "::",
+  //     stringify!(query)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlURI>())).fragment as *const _ as usize },
+  //   64usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlURI),
+  //     "::",
+  //     stringify!(fragment)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlURI>())).cleanup as *const _ as usize },
+  //   72usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlURI),
+  //     "::",
+  //     stringify!(cleanup)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlURI>())).query_raw as *const _ as usize },
+  //   80usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlURI),
+  //     "::",
+  //     stringify!(query_raw)
+  //   )
+  // );
 }
 extern "C" {
   pub fn xmlCreateURI() -> xmlURIPtr;
@@ -20909,36 +20909,36 @@ fn bindgen_test_layout__xmlLocationSet() {
     8usize,
     concat!("Alignment of ", stringify!(_xmlLocationSet))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlLocationSet>())).locNr as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlLocationSet),
-      "::",
-      stringify!(locNr)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlLocationSet>())).locMax as *const _ as usize },
-    4usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlLocationSet),
-      "::",
-      stringify!(locMax)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<_xmlLocationSet>())).locTab as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(_xmlLocationSet),
-      "::",
-      stringify!(locTab)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlLocationSet>())).locNr as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlLocationSet),
+  //     "::",
+  //     stringify!(locNr)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlLocationSet>())).locMax as *const _ as usize },
+  //   4usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlLocationSet),
+  //     "::",
+  //     stringify!(locMax)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<_xmlLocationSet>())).locTab as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(_xmlLocationSet),
+  //     "::",
+  //     stringify!(locTab)
+  //   )
+  // );
 }
 extern "C" {
   pub fn xmlXPtrLocationSetCreate(val: xmlXPathObjectPtr) -> xmlLocationSetPtr;
@@ -21039,44 +21039,44 @@ fn bindgen_test_layout___va_list_tag() {
     8usize,
     concat!("Alignment of ", stringify!(__va_list_tag))
   );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<__va_list_tag>())).gp_offset as *const _ as usize },
-    0usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(__va_list_tag),
-      "::",
-      stringify!(gp_offset)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<__va_list_tag>())).fp_offset as *const _ as usize },
-    4usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(__va_list_tag),
-      "::",
-      stringify!(fp_offset)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<__va_list_tag>())).overflow_arg_area as *const _ as usize },
-    8usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(__va_list_tag),
-      "::",
-      stringify!(overflow_arg_area)
-    )
-  );
-  assert_eq!(
-    unsafe { &(*(::std::ptr::null::<__va_list_tag>())).reg_save_area as *const _ as usize },
-    16usize,
-    concat!(
-      "Offset of field: ",
-      stringify!(__va_list_tag),
-      "::",
-      stringify!(reg_save_area)
-    )
-  );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<__va_list_tag>())).gp_offset as *const _ as usize },
+  //   0usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(__va_list_tag),
+  //     "::",
+  //     stringify!(gp_offset)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<__va_list_tag>())).fp_offset as *const _ as usize },
+  //   4usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(__va_list_tag),
+  //     "::",
+  //     stringify!(fp_offset)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<__va_list_tag>())).overflow_arg_area as *const _ as usize },
+  //   8usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(__va_list_tag),
+  //     "::",
+  //     stringify!(overflow_arg_area)
+  //   )
+  // );
+  // assert_eq!(
+  //   unsafe { &(*(::std::ptr::null::<__va_list_tag>())).reg_save_area as *const _ as usize },
+  //   16usize,
+  //   concat!(
+  //     "Offset of field: ",
+  //     stringify!(__va_list_tag),
+  //     "::",
+  //     stringify!(reg_save_area)
+  //   )
+  // );
 }


### PR DESCRIPTION
The recent versions of rustc are throwing warnings at some bindgen-generated tests, such as:

```
warning: dereferencing a null pointer
     --> src/bindings.rs:17692:15
      |
17692 |     unsafe { &(*(::std::ptr::null::<_xmlSchemaNotation>())).type_ as *const _ as usize },
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
      |
      = note: `#[warn(deref_nullptr)]` on by default
```

This PR simply comments all of those tests out, as an experimental way out. I prefer that to disabling the warning, since the technique sounds dangerous enough to not rely on in general.