### PR TITLE
Box errors with Send and Sync

### DIFF
--- a/src/tree/namespace.rs
+++ b/src/tree/namespace.rs
@@ -18,7 +18,7 @@ pub struct Namespace {
 
 impl Namespace {
   /// Creates a new namespace
-  pub fn new(prefix: &str, href: &str, node: &mut Node) -> Result<Self, Box<dyn Error>> {
+  pub fn new(prefix: &str, href: &str, node: &mut Node) -> Result<Self, Box<dyn Error + Send + Sync>> {
     let c_href = CString::new(href).unwrap();
     let c_prefix = CString::new(prefix).unwrap();
     let c_prefix_ptr = if prefix.is_empty() {

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -335,7 +335,7 @@ impl Node {
   }
 
   /// Add a previous sibling
-  pub fn add_prev_sibling(&mut self, new_sibling: &mut Node) -> Result<(), Box<dyn Error>> {
+  pub fn add_prev_sibling(&mut self, new_sibling: &mut Node) -> Result<(), Box<dyn Error + Send + Sync>> {
     new_sibling.set_linked();
     unsafe {
       if xmlAddPrevSibling(self.node_ptr_mut()?, new_sibling.node_ptr_mut()?).is_null() {
@@ -347,7 +347,7 @@ impl Node {
   }
 
   /// Add a next sibling
-  pub fn add_next_sibling(&mut self, new_sibling: &mut Node) -> Result<(), Box<dyn Error>> {
+  pub fn add_next_sibling(&mut self, new_sibling: &mut Node) -> Result<(), Box<dyn Error + Send + Sync>> {
     new_sibling.set_linked();
     unsafe {
       if xmlAddNextSibling(self.node_ptr_mut()?, new_sibling.node_ptr_mut()?).is_null() {
@@ -384,7 +384,7 @@ impl Node {
   }
 
   /// Sets the name of this `Node`
-  pub fn set_name(&mut self, name: &str) -> Result<(), Box<dyn Error>> {
+  pub fn set_name(&mut self, name: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
     let c_name = CString::new(name).unwrap();
     unsafe { xmlNodeSetName(self.node_ptr_mut()?, c_name.as_bytes().as_ptr()) }
     Ok(())
@@ -407,7 +407,7 @@ impl Node {
   }
 
   /// Sets the text content of this `Node`
-  pub fn set_content(&mut self, content: &str) -> Result<(), Box<dyn Error>> {
+  pub fn set_content(&mut self, content: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
     let c_content = CString::new(content).unwrap();
     unsafe { xmlNodeSetContent(self.node_ptr_mut()?, c_content.as_bytes().as_ptr()) }
     Ok(())
@@ -461,7 +461,7 @@ impl Node {
   }
 
   /// Sets the value of property `name` to `value`
-  pub fn set_property(&mut self, name: &str, value: &str) -> Result<(), Box<dyn Error>> {
+  pub fn set_property(&mut self, name: &str, value: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
     let c_name = CString::new(name).unwrap();
     let c_value = CString::new(value).unwrap();
     unsafe {
@@ -479,7 +479,7 @@ impl Node {
     name: &str,
     value: &str,
     ns: &Namespace,
-  ) -> Result<(), Box<dyn Error>> {
+  ) -> Result<(), Box<dyn Error + Send + Sync>> {
     let c_name = CString::new(name).unwrap();
     let c_value = CString::new(value).unwrap();
     unsafe {
@@ -494,7 +494,7 @@ impl Node {
   }
 
   /// Removes the property of given `name`
-  pub fn remove_property(&mut self, name: &str) -> Result<(), Box<dyn Error>> {
+  pub fn remove_property(&mut self, name: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
     let c_name = CString::new(name).unwrap();
     unsafe {
       let attr_node = xmlHasProp(self.node_ptr_mut()?, c_name.as_bytes().as_ptr());
@@ -517,7 +517,7 @@ impl Node {
   }
 
   /// Removes the property of given `name` and namespace (`ns`)
-  pub fn remove_property_ns(&mut self, name: &str, ns: &str) -> Result<(), Box<dyn Error>> {
+  pub fn remove_property_ns(&mut self, name: &str, ns: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
     let c_name = CString::new(name).unwrap();
     let c_ns = CString::new(ns).unwrap();
     unsafe {
@@ -559,7 +559,7 @@ impl Node {
   }
 
   /// Alias for set_property
-  pub fn set_attribute(&mut self, name: &str, value: &str) -> Result<(), Box<dyn Error>> {
+  pub fn set_attribute(&mut self, name: &str, value: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
     self.set_property(name, value)
   }
   /// Alias for set_property_ns
@@ -568,17 +568,17 @@ impl Node {
     name: &str,
     value: &str,
     ns: &Namespace,
-  ) -> Result<(), Box<dyn Error>> {
+  ) -> Result<(), Box<dyn Error + Send + Sync>> {
     self.set_property_ns(name, value, ns)
   }
 
   /// Alias for remove_property
-  pub fn remove_attribute(&mut self, name: &str) -> Result<(), Box<dyn Error>> {
+  pub fn remove_attribute(&mut self, name: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
     self.remove_property(name)
   }
 
   /// Alias for remove_property_ns
-  pub fn remove_attribute_ns(&mut self, name: &str, ns: &str) -> Result<(), Box<dyn Error>> {
+  pub fn remove_attribute_ns(&mut self, name: &str, ns: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
     self.remove_property_ns(name, ns)
   }
 
@@ -668,7 +668,7 @@ impl Node {
   }
 
   /// Sets a `Namespace` for the node
-  pub fn set_namespace(&mut self, namespace: &Namespace) -> Result<(), Box<dyn Error>> {
+  pub fn set_namespace(&mut self, namespace: &Namespace) -> Result<(), Box<dyn Error + Send + Sync>> {
     unsafe {
       xmlSetNs(self.node_ptr_mut()?, namespace.ns_ptr());
     }
@@ -722,7 +722,7 @@ impl Node {
 
   // TODO: Clear a future Document namespaces vec
   /// Removes the namespaces of this `Node` and it's children!
-  pub fn recursively_remove_namespaces(&mut self) -> Result<(), Box<dyn Error>> {
+  pub fn recursively_remove_namespaces(&mut self) -> Result<(), Box<dyn Error + Send + Sync>> {
     xmlNodeRecursivelyRemoveNs(self.node_ptr_mut()?);
     Ok(())
   }
@@ -752,7 +752,7 @@ impl Node {
   }
 
   /// Creates a new `Node` as child to the self `Node`
-  pub fn new_child(&mut self, ns: Option<Namespace>, name: &str) -> Result<Node, Box<dyn Error>> {
+  pub fn new_child(&mut self, ns: Option<Namespace>, name: &str) -> Result<Node, Box<dyn Error + Send + Sync>> {
     let c_name = CString::new(name).unwrap();
     let ns_ptr = match ns {
       None => ptr::null_mut(),
@@ -775,7 +775,7 @@ impl Node {
     ns: Option<Namespace>,
     name: &str,
     content: &str,
-  ) -> Result<Node, Box<dyn Error>> {
+  ) -> Result<Node, Box<dyn Error + Send + Sync>> {
     let c_name = CString::new(name).unwrap();
     let c_content = CString::new(content).unwrap();
     let ns_ptr = match ns {
@@ -794,7 +794,7 @@ impl Node {
   }
 
   /// Append text to this `Node`
-  pub fn append_text(&mut self, content: &str) -> Result<(), Box<dyn Error>> {
+  pub fn append_text(&mut self, content: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
     let c_len = content.len() as i32;
     if c_len > 0 {
       let c_content = CString::new(content).unwrap();
@@ -878,7 +878,7 @@ impl Node {
     &mut self,
     mut new: Node,
     mut old: Node,
-  ) -> Result<Node, Box<dyn Error>> {
+  ) -> Result<Node, Box<dyn Error + Send + Sync>> {
     // if newNode == oldNode or self == newNode then do nothing, just return nNode.
     if new == old || self == &new {
       // nothing to do here, already in place


### PR DESCRIPTION
Allows errors to be sent between threads safely. Fixes errors such as:

```
`(dyn std::error::Error + 'static)` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `(dyn std::error::Error + 'static)`
    = note: required because of the requirements on the impl of `std::marker::Send` for `std::ptr::Unique<(dyn std::error::Error + 'static)>`
    = note: required because it appears within the type `std::boxed::Box<(dyn std::error::Error + 'static)>`
```