### PR TITLE
01.2022 clippy lints

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ pub struct StructuredError(*mut bindings::_xmlError);
 impl StructuredError {
   /// Wrap around and own a raw xmllib2 error structure
   pub fn from_raw(error: *mut bindings::_xmlError) -> Self {
-    Self { 0: error }
+    Self(error)
   }
 
   /// Human-readable informative error message

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -87,20 +87,18 @@ impl<'a> ParserOptions<'a> {
         }
       };
     }
-
-    let flags = 0;
-    let flags = flags + to_option_flag!(self.recover => Recover);
-    let flags = flags + to_option_flag!(self.no_def_dtd => Nodefdtd);
-    let flags = flags + to_option_flag!(self.no_error => Noerror);
-    let flags = flags + to_option_flag!(self.no_warning => Nowarning);
-    let flags = flags + to_option_flag!(self.no_warning => Nowarning);
-    let flags = flags + to_option_flag!(self.pedantic => Pedantic);
-    let flags = flags + to_option_flag!(self.no_blanks => Noblanks);
-    let flags = flags + to_option_flag!(self.no_net => Nonet);
-    let flags = flags + to_option_flag!(self.no_implied => Noimplied);
-    let flags = flags + to_option_flag!(self.compact => Compact);
-    let flags = flags + to_option_flag!(self.ignore_enc => Ignoreenc);
-    flags
+    // return the combined flags
+    to_option_flag!(self.recover => Recover)
+      + to_option_flag!(self.no_def_dtd => Nodefdtd)
+      + to_option_flag!(self.no_error => Noerror)
+      + to_option_flag!(self.no_warning => Nowarning)
+      + to_option_flag!(self.no_warning => Nowarning)
+      + to_option_flag!(self.pedantic => Pedantic)
+      + to_option_flag!(self.no_blanks => Noblanks)
+      + to_option_flag!(self.no_net => Nonet)
+      + to_option_flag!(self.no_implied => Noimplied)
+      + to_option_flag!(self.compact => Compact)
+      + to_option_flag!(self.ignore_enc => Ignoreenc)
   }
 }
 

--- a/src/schemas/schema.rs
+++ b/src/schemas/schema.rs
@@ -18,7 +18,7 @@ impl Schema {
     if raw.is_null() {
       Err(parser.drain_errors())
     } else {
-      Ok(Self { 0: raw })
+      Ok(Self(raw))
     }
   }
 

--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -16,7 +16,7 @@ use crate::tree::node::Node;
 pub(crate) type DocumentRef = Rc<RefCell<_Document>>;
 pub(crate) type DocumentWeak = Weak<RefCell<_Document>>;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 /// Save Options for Document
 pub struct SaveOptions {
   /// format save output
@@ -35,21 +35,6 @@ pub struct SaveOptions {
   pub as_html: bool,
   /// format with non-significant whitespace
   pub non_significant_whitespace: bool,
-}
-
-impl Default for SaveOptions {
-  fn default() -> Self {
-    SaveOptions {
-      format: false,
-      no_declaration: false,
-      no_empty_tags: false,
-      no_xhtml: false,
-      xhtml: false,
-      as_xml: false,
-      as_html: false,
-      non_significant_whitespace: false,
-    }
-  }
 }
 
 #[derive(Debug)]

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -137,7 +137,7 @@ impl Node {
     // If newly encountered pointer, wrap
     let node = _Node {
       node_ptr,
-      document: Rc::downgrade(&document),
+      document: Rc::downgrade(document),
       unlinked,
     };
     let wrapped_node = Node(Rc::new(RefCell::new(node)));
@@ -170,7 +170,7 @@ impl Node {
   }
   /// Create a mock node, used for a placeholder argument
   pub fn mock(doc: &Document) -> Self {
-    Node::new("mock", None, &doc).unwrap()
+    Node::new("mock", None, doc).unwrap()
   }
 
   /// Create a mock node, used for a placeholder argument
@@ -868,7 +868,7 @@ impl Node {
 
   /// find nodes via xpath, at a specified node or the document root
   pub fn findnodes(&self, xpath: &str) -> Result<Vec<Node>, ()> {
-    let mut context = Context::from_node(&self)?;
+    let mut context = Context::from_node(self)?;
     context.findnodes(xpath, Some(self))
   }
 

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -63,7 +63,7 @@ impl Context {
     } else {
       Ok(Context {
         context_ptr: Rc::new(RefCell::new(_Context(ctxtptr))),
-        document: Rc::downgrade(&docref),
+        document: Rc::downgrade(docref),
       })
     }
   }
@@ -154,23 +154,21 @@ impl Context {
 
   /// find nodes via xpath, at a specified node or the document root
   pub fn findnodes(&mut self, xpath: &str, node_opt: Option<&Node>) -> Result<Vec<Node>, ()> {
-    let evaluated;
-    if let Some(node) = node_opt {
-      evaluated = self.node_evaluate(xpath, node)?;
+    let evaluated = if let Some(node) = node_opt {
+      self.node_evaluate(xpath, node)?
     } else {
-      evaluated = self.evaluate(xpath)?;
-    }
+      self.evaluate(xpath)?
+    };
     Ok(evaluated.get_nodes_as_vec())
   }
 
   /// find a literal value via xpath, at a specified node or the document root
   pub fn findvalue(&mut self, xpath: &str, node_opt: Option<&Node>) -> Result<String, ()> {
-    let evaluated;
-    if let Some(node) = node_opt {
-      evaluated = self.node_evaluate(xpath, node)?;
+    let evaluated = if let Some(node) = node_opt {
+      self.node_evaluate(xpath, node)?
     } else {
-      evaluated = self.evaluate(xpath)?;
-    }
+      self.evaluate(xpath)?
+    };
     Ok(evaluated.to_string())
   }
 }


### PR DESCRIPTION
With the exception of the [result unit lint](https://rust-lang.github.io/rust-clippy/master/index.html#result_unit_err), this PR should patch all new lints from the recent clippy.