### PR TITLE
maybe a better approach to set library path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,11 @@ documentation = "http://kwarc.github.io/rust-libxml/libxml/index.html"
 readme = "README.md"
 license = "MIT"
 keywords = ["xml", "libxml","xpath", "parser", "html"]
+links = "libxml"
 build = "build.rs"
 exclude = [
   "scripts/*"
 ]
-
-[lib]
-name = "libxml"
 
 [dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -26,13 +26,54 @@ Before performing the usual cargo build/install steps, you need to have the rele
 On linux systems you'd need the development headers of libxml2 (e.g. `libxml2-dev` in Debian), as well as `pkg-config`.
 
 ### MacOS
-[Community contributed](https://github.com/KWARC/rust-libxml/issues/88#issuecomment-890876895):
+
+With the ability of [custom cargo configuration](https://doc.rust-lang.org/cargo/reference/config.html), we can now override build scripts per project separately without the need of modifying environment variables.
+
+Firstly, install relevant librarys by [homebrew](https://brew.sh/)
 
 ```
-$ brew install libxml2 # e.g. version 2.9.12 
-$ ln -s /usr/local/Cellar/libxml2/2.9.12/lib/libxml2.2.dylib /usr/local/lib/libxml-2.0.dylib
-$ export LIBXML2=/usr/local/Cellar/libxml2/2.9.12/lib/pkgconfig/libxml-2.0.pc
+$ brew install libxml2 # e.g. version 2.9.13 
 ```
+
+Then we can manually [override](https://doc.rust-lang.org/cargo/reference/config.html#targettriplelinks) the path of native library in a **project-level** configuration separately.
+
+* make sure we are in the same folder where `Cargo.toml` located in.
+* create a dir named `.cargo` with a file named `config.toml` in it. 
+* Then add our custom build configuration like below. Also, don't forget to change the target and library paths to yours.
+
+  
+```
+$ cd /path/to/your/project
+$ mkdir .cargo
+$ vim .cargo/config.toml
+$ cat .cargo/config.toml
+[target.YOUR_TARGET.libxml]
+rustc-link-lib = ["xml2"]
+rustc-link-search = ["/path/to/lib"]
+```
+
+Targets may **different** between the archs and operating systems you are using. To figure out which you should use, simply run `rustup target list`, then replace `YOUR_TARGET` by the name of the installed one.
+
+```
+$ rustup target list
+aarch64-apple-darwin (installed)
+aarch64-apple-ios
+aarch64-apple-ios-sim
+aarch64-fuchsia
+aarch64-linux-android
+...
+...
+...
+
+# so we edit config.toml like below:
+$ cat .cargo/config.toml
+[target.aarch64-apple-darwin.libxml]
+rustc-link-lib = ["xml2"]
+rustc-link-search = ["/opt/homebrew/opt/libxml2/lib/"]
+```
+
+
+`rustc-link-search` indicates the path where compiler would try to find native library in. It should be set according to your own environment.
 
 ### Windows
 
@@ -48,3 +89,5 @@ C:\> refreshenv
 C:\> vcpkg install libxml2:x64-windows
 C:\> vcpkg integrate install
 ```
+
+If you encounter any errors in the build script(`build.rs`), just do the same steps to manually set the path in section `MacOS` above 


### PR DESCRIPTION
When I use this module, the rust compiler always couldn't find where the libxml2 located in. I just want to find out if there is a proper way to define a valid path of native library to compiler? 

After several hours searching, I found something in official document website that I want to discuss.

## link or links?
I tried to find a official introduction about the [`link` section](https://github.com/KWARC/rust-libxml/blob/e7e1170e31febfc6fbda12af6aac01bb23edbad3/Cargo.toml#L17), but found [nothing](https://doc.rust-lang.org/cargo/reference/manifest.html). Maybe I missed something?

Instead, there is a similar field named [`links`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-links-field) in `package` section.

By using this field, we can override the build parameters by providing a [project-level](https://stackoverflow.com/a/54801479) configuration, and no need to modify environment variables or create any softlink. 

Documents about overriding build scripts are [here](https://doc.rust-lang.org/cargo/reference/build-scripts.html#overriding-build-scripts).

In this situation, build scripts will be disabled since a target-override is provided.
> The override method would not work when we use `link` section instead of `links` field.

## conclusion
I have no idea whether this is a better approach, compared with some manual filesystem operations?

So I create this to discuss it, please feel free to comment, edit or close this PR.  

I'm not familiar with how to submit a PR, but I would be very happy if this could help somehow. And thank you for your continuously brilliant work! 