### PR TITLE
add Context::findvalues, Node::findvalues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 
-## [0.3.2] (in development)
+## [0.3.3] (in development)
+
+## [0.3.2] 2023-07-05
+
+### Added
+
+* XPath: `Context::findvalues`, with optional node-bound evaluation, obtaining `String` values.
+
+* `Node::findvalues` method for direct XPath search obtaining `String` values, without first explicitly instantiating a `Context`. Reusing a `Context` remains more efficient.
 
 ## [0.3.1] 2022-26-03
 

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -929,6 +929,12 @@ impl Node {
     context.findnodes(xpath, Some(self))
   }
 
+  /// find String values via xpath, at a specified node or the document root
+  pub fn findvalues(&self, xpath: &str) -> Result<Vec<String>, ()> {
+    let mut context = Context::from_node(self)?;
+    context.findvalues(xpath, Some(self))
+  }
+
   /// replace a `self`'s `old` child node with a `new` node in the same position
   /// borrowed from Perl's XML::LibXML
   pub fn replace_child_node(

--- a/tests/resources/ids.xml
+++ b/tests/resources/ids.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<document>
+  <test>
+    <empty/>
+  </test>
+  <test>
+    <p xml:id="start">Hello</p>
+    <deeper>
+      <p xml:id="mid"> </p>
+    </deeper>
+    <deeper>
+      <still>
+        <p xml:id="end">World!</p>
+      </still>
+    </deeper>
+  </test>
+</document>

--- a/tests/xpath_tests.rs
+++ b/tests/xpath_tests.rs
@@ -193,6 +193,29 @@ fn cleanup_safely_unlinked_xpath_nodes() {
   assert!(true, "Drops went OK.");
 }
 
+#[test]
+fn xpath_find_string_values() {
+  let parser = Parser::default();
+  let doc_result = parser.parse_file("tests/resources/ids.xml");
+  assert!(doc_result.is_ok());
+  let doc = doc_result.unwrap();
+  let mut xpath = libxml::xpath::Context::new(&doc).unwrap();
+  if let Some(root) = doc.get_root_element() {
+    let tests = root.get_child_elements();
+    let empty_test = &tests[0];
+    let ids_test = &tests[1];
+    let empty_values = xpath.findvalues(".//@xml:id", Some(empty_test));
+    assert_eq!(empty_values, Ok(Vec::new()));
+    let ids_values = xpath.findvalues(".//@xml:id", Some(ids_test));
+    let expected_ids = Ok(vec![String::from("start"),String::from("mid"),String::from("end")]);
+    assert_eq!(ids_values, expected_ids);
+    let node_ids_values = ids_test.findvalues(".//@xml:id");
+    assert_eq!(node_ids_values, expected_ids);
+  } else {
+    panic!("Document fails to obtain root!");
+  }
+}
+
 /// Tests for checking xpath well-formedness
 mod compile_tests {
   use libxml::xpath::is_well_formed_xpath;


### PR DESCRIPTION
I needed a convenience helper for string-oriented XPath selectors, such as `.//@xml:id`

So I added a `findvalues` variant, based on [xmlXPathCastNodeToString](https://gnome.pages.gitlab.gnome.org/libxml2/devhelp/libxml2-xpath.html#xmlXPathCastNodeToString). 

Hopefully nothing tricky here, and maybe a good time to add a minor release to signal the wrapper is still alive.