### PR TITLE
parser: Fix computed option flag values

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -89,7 +89,6 @@ impl<'a> ParserOptions<'a> {
       + to_option_flag!(self.no_def_dtd => Nodefdtd)
       + to_option_flag!(self.no_error => Noerror)
       + to_option_flag!(self.no_warning => Nowarning)
-      + to_option_flag!(self.no_warning => Nowarning)
       + to_option_flag!(self.pedantic => Pedantic)
       + to_option_flag!(self.no_blanks => Noblanks)
       + to_option_flag!(self.no_net => Nonet)


### PR DESCRIPTION
`no_warning` (64) is added twice, resulting in 128 (`pedantic`), so if you have `no_warning` set, you actually end up with `pedantic` :sweat_smile: 

The rest of this code is correct.