### PR TITLE
Enable processing of files over 10Mb

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,6 +26,7 @@ enum XmlParserOption {
   Nonet = 2048,
   Noimplied = 8192,
   Compact = 65_536,
+  Huge = 524_288,
   Ignoreenc = 2_097_152,
 }
 
@@ -38,6 +39,7 @@ enum HtmlParserOption {
   Noblanks = 256,
   Nonet = 2048,
   Noimplied = 8192,
+  Huge = 524_288,
   Compact = 65_536,
   Ignoreenc = 2_097_152,
 }
@@ -60,6 +62,8 @@ pub struct ParserOptions<'a> {
   pub no_net: bool,
   /// Do not add implied html/body... elements
   pub no_implied: bool,
+  /// relax any hardcoded limit from the parser
+  pub huge: bool,
   /// compact small text nodes
   pub compact: bool,
   /// ignore internal document encoding hint
@@ -93,6 +97,7 @@ impl<'a> ParserOptions<'a> {
       + to_option_flag!(self.no_blanks => Noblanks)
       + to_option_flag!(self.no_net => Nonet)
       + to_option_flag!(self.no_implied => Noimplied)
+      + to_option_flag!(self.huge => Huge)
       + to_option_flag!(self.compact => Compact)
       + to_option_flag!(self.ignore_enc => Ignoreenc)
   }
@@ -109,6 +114,7 @@ impl<'a> Default for ParserOptions<'a> {
       no_blanks: false,
       no_net: false,
       no_implied: false,
+      huge: false,
       compact: false,
       ignore_enc: false,
       encoding: None,


### PR DESCRIPTION
For security reasons [1], the libxml2 library has a hardcoded limit of 10Mb for processing files.
The library offers the `XML_PARSE_HUGE` entry as part of the `xmlParserOption` enum to allow programmers to override this limit.
This option can be given to the `xmlReadMemory` function to allow the processing of files over the 10Mb limit.

This patch adds the `huge` option to the `ParserOptions` struct to allow rust-libxml parse with options functions to use this feature.

[1] https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-4226