### PR TITLE
feat(error-handling): change panics into recoverable results

### DIFF
--- a/examples/schema_example.rs
+++ b/examples/schema_example.rs
@@ -11,7 +11,13 @@ fn main() {
     .parse_file("tests/resources/schema.xml")
     .expect("Expected to be able to parse XML Document from file");
 
-  let mut xsdparser = SchemaParserContext::from_file("tests/resources/schema.xsd");
+  let mut xsdparser =
+    SchemaParserContext::from_file("tests/resources/schema.xsd").unwrap_or_else(|err| {
+      println!("{}", err.message.as_ref().unwrap());
+
+      panic!("Failed to create parsing context");
+    });
+
   let xsd = SchemaValidationContext::from_parser(&mut xsdparser);
 
   if let Err(errors) = xsd {

--- a/src/error.rs
+++ b/src/error.rs
@@ -94,32 +94,35 @@ impl StructuredError {
     }
   }
 
-  // pub fn new(message: &str, level: XmlErrorLevel) -> Self {
-  //   StructuredError {
-  //     message: Some(message.into()),
-  //     level,
-  //     filename,
-  //     line,
-  //     col,
-  //     domain: error.domain,
-  //     code: error.code,
-  //   }
-  // }
-
-  /// TODO: doc
-  pub fn null_ptr() -> Self {
+  /// Creates a custom `StructuredError`to report unexpected 0-byte when attempting to convert `Vec<u8>` to `CString`
+  pub fn cstring_error(position: usize) -> Self {
     StructuredError {
-      message: Some("Failed to create validation context from XML schema".into()),
+      message: Some(
+        format!("Path contained an unexpected null-terminator at position {position}. String must not contain any 0-bytes."),
+      ),
       level: XmlErrorLevel::Fatal,
       filename: None,
       line: None,
       col: None,
-      domain: 0, /* TODO: check codes */
-      code: 0,
+      domain: 0,
+      code: -1,
     }
   }
 
-  /// TODO: doc
+  /// Creates a custom `StructuredError`to report an invalid pointer-reference
+  pub fn null_ptr() -> Self {
+    StructuredError {
+      message: Some("Could not create context due to an unexpected null-reference.".into()),
+      level: XmlErrorLevel::Fatal,
+      filename: None,
+      line: None,
+      col: None,
+      domain: 0,
+      code: -1,
+    }
+  }
+
+  /// Wraps the `libxml2` internal error (exit-code `-1`) in a `StructuredError`
   pub fn internal() -> Self {
     StructuredError {
       message: Some("Failed to validate file due to internal error".into()),
@@ -127,8 +130,8 @@ impl StructuredError {
       filename: None,
       line: None,
       col: None,
-      domain: 0, /* TODO: check codes */
-      code: 0,
+      domain: 0,
+      code: -1,
     }
   }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,12 +57,12 @@ pub struct StructuredError {
 
 impl StructuredError {
   /// Copies the error information stored at `error_ptr` into a new `StructuredError`
-  /// 
+  ///
   /// # Safety
   /// This function must be given a pointer to a valid `xmlError` struct. Typically, you
   /// will acquire such a pointer by implementing one of a number of callbacks
   /// defined in libXml which are provided an `xmlError` as an argument.
-  /// 
+  ///
   /// This function copies data from the memory `error_ptr` but does not deallocate
   /// the error. Depending on the context in which this function is used, you may
   /// need to take additional steps to avoid a memory leak.
@@ -94,12 +94,53 @@ impl StructuredError {
     }
   }
 
+  // pub fn new(message: &str, level: XmlErrorLevel) -> Self {
+  //   StructuredError {
+  //     message: Some(message.into()),
+  //     level,
+  //     filename,
+  //     line,
+  //     col,
+  //     domain: error.domain,
+  //     code: error.code,
+  //   }
+  // }
+
+  /// TODO: doc
+  pub fn null_ptr() -> Self {
+    StructuredError {
+      message: Some("Failed to create validation context from XML schema".into()),
+      level: XmlErrorLevel::Fatal,
+      filename: None,
+      line: None,
+      col: None,
+      domain: 0, /* TODO: check codes */
+      code: 0,
+    }
+  }
+
+  /// TODO: doc
+  pub fn internal() -> Self {
+    StructuredError {
+      message: Some("Failed to validate file due to internal error".into()),
+      level: XmlErrorLevel::Fatal,
+      filename: None,
+      line: None,
+      col: None,
+      domain: 0, /* TODO: check codes */
+      code: 0,
+    }
+  }
+
   /// Human-readable informative error message.
-  /// 
+  ///
   /// This function is a hold-over from the original bindings to libxml's error
-  /// reporting mechanism. Instead of calling this method, you can access the 
+  /// reporting mechanism. Instead of calling this method, you can access the
   /// StructuredError `message` field directly.
-  #[deprecated(since="0.3.3", note="Please use the `message` field directly instead.")]
+  #[deprecated(
+    since = "0.3.3",
+    note = "Please use the `message` field directly instead."
+  )]
   pub fn message(&self) -> &str {
     self.message.as_deref().unwrap_or("")
   }

--- a/src/schemas/validation.rs
+++ b/src/schemas/validation.rs
@@ -33,7 +33,7 @@ impl SchemaValidationContext {
         let ctx = unsafe { bindings::xmlSchemaNewValidCtxt(s.as_ptr()) };
 
         if ctx.is_null() {
-          panic!("Failed to create validation context from XML schema") // TODO error handling
+          return Err(vec![StructuredError::null_ptr()]);
         }
 
         Ok(Self::from_raw(ctx, s))
@@ -48,7 +48,7 @@ impl SchemaValidationContext {
     let rc = unsafe { bindings::xmlSchemaValidateDoc(self.ctxt, doc.doc_ptr()) };
 
     match rc {
-      -1 => panic!("Failed to validate document due to internal error"), // TODO error handling
+      -1 => Err(vec![StructuredError::internal()]),
       0 => Ok(()),
       _ => Err(self.drain_errors()),
     }
@@ -62,7 +62,7 @@ impl SchemaValidationContext {
     let rc = unsafe { bindings::xmlSchemaValidateFile(self.ctxt, path_ptr, 0) };
 
     match rc {
-      -1 => panic!("Failed to validate file due to internal error"), // TODO error handling
+      -1 => Err(vec![StructuredError::internal()]),
       0 => Ok(()),
       _ => Err(self.drain_errors()),
     }
@@ -73,7 +73,7 @@ impl SchemaValidationContext {
     let rc = unsafe { bindings::xmlSchemaValidateOneElement(self.ctxt, node.node_ptr()) };
 
     match rc {
-      -1 => panic!("Failed to validate element due to internal error"), // TODO error handling
+      -1 => Err(vec![StructuredError::internal()]),
       0 => Ok(()),
       _ => Err(self.drain_errors()),
     }

--- a/src/schemas/validation.rs
+++ b/src/schemas/validation.rs
@@ -56,7 +56,8 @@ impl SchemaValidationContext {
 
   /// Validates a given file from path for its compliance with the loaded XSD schema definition
   pub fn validate_file(&mut self, path: &str) -> Result<(), Vec<StructuredError>> {
-    let path = CString::new(path).unwrap(); // TODO error handling for \0 containing strings
+    let path =
+      CString::new(path).map_err(|err| vec![StructuredError::cstring_error(err.nul_position())])?;
     let path_ptr = path.as_bytes_with_nul().as_ptr() as *const c_char;
 
     let rc = unsafe { bindings::xmlSchemaValidateFile(self.ctxt, path_ptr, 0) };


### PR DESCRIPTION
There are some rust-fmt changes due to differing formatting rules which I might need to revert.
Also I didn't add tests for the new `null_ptr` and `internal` `StructuredError` functions since I felt like it's not really necessary, however I am happy to add those if you feel like they are needed after all.

Refs: #120 