### PR TITLE
Display LIBXML2 env value on build errors.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,8 +3,15 @@ fn main() {
     // println!("{:?}", std::env::vars());
     // panic!("set libxml2.");
     let p = std::path::Path::new(s);
-    let fname = std::path::Path::new(p.file_name().expect("no file name in LIBXML2 env"));
-    assert!(p.is_file());
+    let fname = std::path::Path::new(
+      p.file_name()
+        .unwrap_or_else(|| panic!("no file name in LIBXML2 env ({s})")),
+    );
+    assert!(
+      p.is_file(),
+      "{}",
+      &format!("not a file in LIBXML2 env ({s})")
+    );
     println!(
       "cargo:rustc-link-lib={}",
       fname


### PR DESCRIPTION
This PR add a (very small) improvment in case `LIBXML2` env value is misconfigured.
I've encountered this probleme while porting [Hurl](https://github.com/Orange-OpenSource/hurl) to [conda-forge](https://github.com/conda-forge) where `LIBXML2` value is set to "2.11". 

Before the PR:

```shell
$ export LIBXML2="2.11"
$ cargo build
   Compiling libxml v0.3.3 (/Users/jc/Documents/Dev/rust-libxml)
error: failed to run custom build command for `libxml v0.3.3 (/Users/jc/Documents/Dev/rust-libxml)`

Caused by:
  process didn't exit successfully: `/Users/jc/Documents/Dev/rust-libxml/target/debug/build/libxml-5bb5ffa4b9ec77c1/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at build.rs:7:5:
  assertion failed: p.is_file()
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After the PR:

```shell
$ export LIBXML2="2.11"
   Compiling libxml v0.3.3 (/Users/jc/Documents/Dev/rust-libxml)
error: failed to run custom build command for `libxml v0.3.3 (/Users/jc/Documents/Dev/rust-libxml)`

Caused by:
  process didn't exit successfully: `/Users/jc/Documents/Dev/rust-libxml/target/debug/build/libxml-5bb5ffa4b9ec77c1/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at build.rs:10:5:
  not a file in LIBXML2 env (2.11)
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

In a nutshell `assertion failed: p.is_file()` vs `not a file in LIBXML2 env (2.11)`


(`build.rs` have been formatted with `cargo fmt` and lint with `cargo clippy`)


