### PR TITLE
Add get_property_no_ns to Node and RoNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.3.4] (in development)
 
+### Added
+
+* Node methods: `get_property_no_ns` (alias: `get_attribute_no_ns`)
+
 ## [0.3.3] 2023-17-07
 
 ### Changed

--- a/src/readonly/tree.rs
+++ b/src/readonly/tree.rs
@@ -251,6 +251,21 @@ impl RoNode {
     Some(prop_str)
   }
 
+  /// Returns the value of property `name` with no namespace
+  pub fn get_property_no_ns(self, name: &str) -> Option<String> {
+    let c_name = CString::new(name).unwrap();
+    let value_ptr = unsafe { xmlGetNoNsProp(self.0, c_name.as_bytes().as_ptr()) };
+    if value_ptr.is_null() {
+      return None;
+    }
+    let c_value_string = unsafe { CStr::from_ptr(value_ptr as *const c_char) };
+    let prop_str = c_value_string.to_string_lossy().into_owned();
+    unsafe {
+      libc::free(value_ptr as *mut c_void);
+    }
+    Some(prop_str)
+  }
+
   /// Return an attribute as a `Node` struct of type AttributeNode
   pub fn get_property_node(self, name: &str) -> Option<RoNode> {
     let c_name = CString::new(name).unwrap();
@@ -264,9 +279,15 @@ impl RoNode {
   pub fn get_attribute(self, name: &str) -> Option<String> {
     self.get_property(name)
   }
+
   /// Alias for get_property_ns
   pub fn get_attribute_ns(self, name: &str, ns: &str) -> Option<String> {
     self.get_property_ns(name, ns)
+  }
+
+  /// Alias for get_property_no_ns
+  pub fn get_attribute_no_ns(self, name: &str) -> Option<String> {
+    self.get_property_no_ns(name)
   }
 
   /// Alias for get_property_node

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -457,6 +457,21 @@ impl Node {
     Some(prop_str)
   }
 
+  /// Returns the value of property `name` with no namespace
+  pub fn get_property_no_ns(&self, name: &str) -> Option<String> {
+    let c_name = CString::new(name).unwrap();
+    let value_ptr = unsafe { xmlGetNoNsProp(self.node_ptr(), c_name.as_bytes().as_ptr()) };
+    if value_ptr.is_null() {
+      return None;
+    }
+    let c_value_string = unsafe { CStr::from_ptr(value_ptr as *const c_char) };
+    let prop_str = c_value_string.to_string_lossy().into_owned();
+    unsafe {
+      libc::free(value_ptr as *mut c_void);
+    }
+    Some(prop_str)
+  }
+
   /// Return an attribute as a `Node` struct of type AttributeNode
   pub fn get_property_node(&self, name: &str) -> Option<Node> {
     let c_name = CString::new(name).unwrap();
@@ -590,9 +605,15 @@ impl Node {
   pub fn get_attribute(&self, name: &str) -> Option<String> {
     self.get_property(name)
   }
+
   /// Alias for get_property_ns
   pub fn get_attribute_ns(&self, name: &str, ns: &str) -> Option<String> {
     self.get_property_ns(name, ns)
+  }
+
+  /// Alias for get_property_no_ns
+  pub fn get_attribute_no_ns(&self, name: &str) -> Option<String> {
+    self.get_property_no_ns(name)
   }
 
   /// Alias for get_property_node

--- a/tests/tree_tests.rs
+++ b/tests/tree_tests.rs
@@ -168,6 +168,47 @@ fn attribute_namespace_accessors() {
 }
 
 #[test]
+fn attribute_no_namespace() {
+  let mut doc = Document::new().unwrap();
+  let element_result = Node::new("example", None, &doc);
+  assert!(element_result.is_ok());
+
+  let mut element = element_result.unwrap();
+  doc.set_root_element(&element);
+
+  let ns_result = Namespace::new("myns", "https://www.example.com/myns", &mut element);
+  assert!(ns_result.is_ok());
+  let ns = ns_result.unwrap();
+  assert!(element.set_attribute_ns("foo", "ns", &ns).is_ok());
+
+  let foo_ns_attr = element.get_attribute_ns("foo", "https://www.example.com/myns");
+  assert!(foo_ns_attr.is_some());
+  assert_eq!(foo_ns_attr.unwrap(), "ns");
+
+  let foo_no_ns_attr = element.get_attribute_no_ns("foo");
+  assert!(foo_no_ns_attr.is_none());
+
+  assert!(element.set_attribute("foo", "no_ns").is_ok());
+
+  let foo_no_ns_attr = element.get_attribute_no_ns("foo");
+  assert!(foo_no_ns_attr.is_some());
+  assert_eq!(foo_no_ns_attr.unwrap(), "no_ns");
+
+  // TODO: include this when `remove_attribute_no_ns` is implemented
+  // It's not possible use remove_attribute here as it removes the first
+  // attribute found with the local name regardless of the namespace; here it
+  // removes the attribute with the namespace
+  // assert!(element.remove_attribute_no_ns("foo").is_ok());
+  // let foo_no_ns_attr = element.get_attribute_no_ns("foo");
+  // assert!(foo_no_ns_attr.is_none());
+
+  assert!(element.set_attribute("bar", "bar").is_ok());
+  let bar_no_ns_attr = element.get_attribute_no_ns("bar");
+  assert!(bar_no_ns_attr.is_some());
+  assert_eq!(bar_no_ns_attr.unwrap(), "bar");
+}
+
+#[test]
 fn node_can_unbind() {
   let mut doc = Document::new().unwrap();
   let element_result = Node::new("example", None, &doc);


### PR DESCRIPTION
The method `get_property_no_ns` was added to `Node` and `RoNode` in line with this [issue](https://github.com/KWARC/rust-libxml/issues/125).

The method `get_property` returns the value of the first property with a given local name, regardless of namespace. This can lead to undesirable results when an element has multiple properties with the same local name. For example, calling it with "bar" on the node below returns "NS BAR" instead of "BAR".
```XML
<foo xmlns:ns="http://example.com" ns:bar="NS BAR" bar="BAR" />
```
On the other hand, the method `get_property_no_ns` returns the value of the nonprefixed property.