### PR TITLE
Add get_properties_ns to Node and RoNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-* Node methods: `get_property_no_ns` (alias: `get_attribute_no_ns`)
+* Node methods: `get_property_no_ns` (alias: `get_attribute_no_ns`), `get_properties_ns` (alias: `get_attributes_ns`) 
+* Added implementations of `Hash`, `PartialEq` and `Eq` traits for `Namespace` 
 
 ## [0.3.3] 2023-17-07
 

--- a/src/c_helpers.rs
+++ b/src/c_helpers.rs
@@ -67,6 +67,9 @@ pub fn xmlNextPropertySibling(attr: xmlAttrPtr) -> xmlAttrPtr {
 pub fn xmlAttrName(attr: xmlAttrPtr) -> *const c_char {
   unsafe { (*attr).name as *const c_char }
 }
+pub fn xmlAttrNs(attr: xmlAttrPtr) -> xmlNsPtr {
+  unsafe { (*attr).ns }
+}
 pub fn xmlGetFirstProperty(node: xmlNodePtr) -> xmlAttrPtr {
   unsafe { (*node).properties }
 }

--- a/src/tree/namespace.rs
+++ b/src/tree/namespace.rs
@@ -2,6 +2,7 @@
 //!
 use std::error::Error;
 use std::ffi::{CStr, CString};
+use std::hash::{Hash, Hasher};
 use std::ptr;
 use std::str;
 
@@ -14,6 +15,21 @@ use crate::tree::node::Node;
 pub struct Namespace {
   ///libxml's xmlNsPtr
   pub(crate) ns_ptr: xmlNsPtr,
+}
+
+impl PartialEq for Namespace {
+  fn eq(&self, other: &Self) -> bool {
+    self.get_prefix() == other.get_prefix() && self.get_href() == other.get_href()
+  }
+}
+
+impl Eq for Namespace {}
+
+impl Hash for Namespace {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    self.get_prefix().hash(state);
+    self.get_href().hash(state);
+  }
 }
 
 impl Namespace {

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -656,21 +656,41 @@ impl Node {
   /// Get a copy of the attributes of this node
   pub fn get_properties(&self) -> HashMap<String, String> {
     let mut attributes = HashMap::new();
-    let mut attr_names = Vec::new();
-    unsafe {
-      let mut current_prop = xmlGetFirstProperty(self.node_ptr());
-      while !current_prop.is_null() {
-        let name_ptr = xmlAttrName(current_prop);
-        let c_name_string = CStr::from_ptr(name_ptr);
-        let name = c_name_string.to_string_lossy().into_owned();
-        attr_names.push(name);
-        current_prop = xmlNextPropertySibling(current_prop);
-      }
-    }
 
-    for name in attr_names {
+    let mut current_prop = xmlGetFirstProperty(self.node_ptr());
+    while !current_prop.is_null() {
+      let name_ptr = xmlAttrName(current_prop);
+      let c_name_string = unsafe { CStr::from_ptr(name_ptr) };
+      let name = c_name_string.to_string_lossy().into_owned();
       let value = self.get_property(&name).unwrap_or_default();
       attributes.insert(name, value);
+      current_prop = xmlNextPropertySibling(current_prop);
+    }
+
+    attributes
+  }
+
+  /// Get a copy of this node's attributes and their namespaces
+  pub fn get_properties_ns(&self) -> HashMap<(String, Option<Namespace>), String> {
+    let mut attributes = HashMap::new();
+
+    let mut current_prop = xmlGetFirstProperty(self.node_ptr());
+    while !current_prop.is_null() {
+      let name_ptr = xmlAttrName(current_prop);
+      let c_name_string = unsafe { CStr::from_ptr(name_ptr) };
+      let name = c_name_string.to_string_lossy().into_owned();
+      let ns_ptr = xmlAttrNs(current_prop);
+      if ns_ptr.is_null() {
+        let value = self.get_property_no_ns(&name).unwrap_or_default();
+        attributes.insert((name, None), value);
+      } else {
+        let ns = Namespace { ns_ptr };
+        let value = self
+          .get_property_ns(&name, &ns.get_href())
+          .unwrap_or_default();
+        attributes.insert((name, Some(ns)), value);
+      }
+      current_prop = xmlNextPropertySibling(current_prop);
     }
 
     attributes
@@ -679,6 +699,11 @@ impl Node {
   /// Alias for `get_properties`
   pub fn get_attributes(&self) -> HashMap<String, String> {
     self.get_properties()
+  }
+
+  /// Alias for `get_properties_ns`
+  pub fn get_attributes_ns(&self) -> HashMap<(String, Option<Namespace>), String> {
+    self.get_properties_ns()
   }
 
   /// Gets the active namespace associated of this node

--- a/tests/resources/file01_ns.xml
+++ b/tests/resources/file01_ns.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+    <!--
+        According to the Namespaces in XML 1.1 (Second Edition) specification, https://www.w3.org/TR/xml-names11/#uniqAttrs, we should not have a node like this
+        <child xmlns:foo="http://www.example.com/myns" xmlns:bar="http://www.example.com/myns" attribute="value1" foo:attribute="foo1" bar:attribute="bar1">some text</child>
+        as both `foo` and `bar` have been bound to identical namespace names.
+    -->
+    <child xmlns:foo="http://www.example.com/myns" xmlns:bar="http://www.example.com/myns" attribute="value1" foo:attribute="foo1" bar:attr="bar1">some text</child>
+    <child xmlns:foo="http://www.example.com/myns" attribute="value2" foo:attribute="foo2" />
+    <child xmlns:bar="http://www.example.com/myns" attribute="value3" bar:attribute="bar3">more text</child>
+</root>


### PR DESCRIPTION
The method `get_properties_ns` was added to `Node` and `RoNode` in line with this [issue](https://github.com/KWARC/rust-libxml/issues/104).

It returns a `HashMap` of attribute values, which is indexed by tuples of the attributes and their namespaces.

The code is similar to that of `get_properties`. However, `get_properties` used unnecessary vector allocation `attr_names`, which is removed in the PR.

The indexing mentioned above required implementing the traits `Hash`, `PartialEq` and `Eq` for `Namespace`. These were implemented using the methods `get_prefix ` and `get_href` instead of `ns_ptr`. This choice does not affect the method `get_properties_ns` as a prefix is bound to a single namespace name in a given scope. However, this has the effect that the two namespaces declared below are considered identical.
```XML
<root>
    <child1 xmlns:foo="http://www.example.com/myns" attribute="value1" foo:attribute="foo1" />
    <child2 xmlns:foo="http://www.example.com/myns" attribute="value2" foo:attribute="foo2" />
</root>
```