### PR TITLE
Implement xpath error message handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.rlib
 *.dll
 Cargo.lock
+.DS_Store
 
 # Executables
 *.exe

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -14927,6 +14927,13 @@ extern "C" {
     -> ::std::os::raw::c_int;
 }
 extern "C" {
+  pub fn xmlXPathSetErrorHandler(
+    ctxt: xmlXPathContextPtr,
+    handler: xmlStructuredErrorFunc,
+    data: *mut ::std::os::raw::c_void,
+  );
+}
+extern "C" {
   pub fn xmlXPathNodeEval(
     node: xmlNodePtr,
     str: *const xmlChar,

--- a/src/schemas/mod.rs
+++ b/src/schemas/mod.rs
@@ -16,3 +16,4 @@ use schema::Schema; // internally handled by SchemaValidationContext
 
 pub use parser::SchemaParserContext;
 pub use validation::SchemaValidationContext;
+pub use common::structured_error_handler;

--- a/tests/xpath_tests.rs
+++ b/tests/xpath_tests.rs
@@ -207,7 +207,11 @@ fn xpath_find_string_values() {
     let empty_values = xpath.findvalues(".//@xml:id", Some(empty_test));
     assert_eq!(empty_values, Ok(Vec::new()));
     let ids_values = xpath.findvalues(".//@xml:id", Some(ids_test));
-    let expected_ids = Ok(vec![String::from("start"),String::from("mid"),String::from("end")]);
+    let expected_ids = Ok(vec![
+      String::from("start"),
+      String::from("mid"),
+      String::from("end"),
+    ]);
     assert_eq!(ids_values, expected_ids);
     let node_ids_values = ids_test.findvalues(".//@xml:id");
     assert_eq!(node_ids_values, expected_ids);
@@ -216,6 +220,28 @@ fn xpath_find_string_values() {
   }
 }
 
+#[test]
+// brew install --HEAD libxml2
+// export LIBXML2=`ls /opt/homebrew/Cellar/libxml2/*/lib/libxml2.dylib` && echo $LIBXML2
+// cargo clean
+// cargo test
+fn xpath_context_new() {
+  let parser = Parser::default_html();
+  let doc_result = parser.parse_file("tests/resources/file02.xml");
+  assert!(doc_result.is_ok());
+  let doc = doc_result.unwrap();
+
+  // Xpath interface
+  let mut context = Context::new(&doc).unwrap();
+  match context.evaluate("/html/un:body") {
+    Ok(_) => assert!(false),
+    Err(e) => {
+      // for msg in context.drain_errors() {
+        // assert_eq!(1,msg.code);
+      // }
+    }
+  }
+}
 /// Tests for checking xpath well-formedness
 mod compile_tests {
   use libxml::xpath::is_well_formed_xpath;


### PR DESCRIPTION
See #133 for context.

Two issues so far: 
1. The first test isn't correct yet. I wanted to start this PR. 
2. After each source change I have to redefine `LIBXML2`. I'm not sure how to tell Cargo where the correct libxml2 resides. I think it's finding the Apple version, not the `brew` version. There's also a MacPorts version that might be in the search path.
