### PR TITLE
build: mark `max_align_t` as opaque to fix i386 build failure

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -57,6 +57,7 @@ fn find_libxml2() -> Option<Vec<PathBuf>> {
 fn generate_bindings(header_dirs: Vec<PathBuf>, output_path: &Path) {
   let bindings = bindgen::Builder::default()
     .header("src/wrapper.h")
+    .opaque_type("max_align_t")
     // invalidate build as soon as the wrapper changes
     .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
     .layout_tests(true)


### PR DESCRIPTION
Avoid layout evaluation of `max_align_t` by marking it as opaque in the bindgen configuration. This prevents an overflow (`16_usize - 24_usize`) on 32-bit targets such as i386.

This change fixes a build failure on Debian i386 reported here[1], on version 0.3.4.

This issue was triggered by bindgen attempting to compute the layout of `max_align_t`, which can vary across platforms and cause invalid assumptions when compiling for 32-bit architectures.

This was also reported in the past here[2].

[1]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1103580
[2]: https://github.com/rust-lang/rust-bindgen/issues/1338