### PR TITLE
Compatibility with libxml2 >= 2.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,3 +27,35 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+  test-libxml2_12:
+    name: With libxml 2.12
+    runs-on: ubuntu-latest
+    steps:
+      - name: install dependencies
+        uses: ryankurte/action-apt@v0.2.0
+        with:
+          packages: "libpython3-dev"
+      - uses: actions/checkout@v2
+      - name: Install libxml 2.12 by hand
+        run: |
+          wget https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.9.tar.xz
+          tar xf libxml2-2.12.9.tar.xz
+          cd libxml2-2.12.9
+          ./configure
+          make
+          cp libxml-2.0-uninstalled.pc libxml-2.0.pc
+          cd include
+          ln -s . libxml2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+        env:
+          PKG_CONFIG_PATH: "./libxml2-2.12.9"
+

--- a/src/c_helpers.rs
+++ b/src/c_helpers.rs
@@ -97,7 +97,17 @@ pub fn xmlNodeGetName(cur: xmlNodePtr) -> *const c_char {
 }
 
 // dummy function: no debug output at all
+#[cfg(libxml_older_than_2_12)]
 unsafe extern "C" fn _ignoreInvalidTagsErrorFunc(_user_data: *mut c_void, error: xmlErrorPtr) {
+  unsafe {
+    if !error.is_null() && (*error).code as u32 == xmlParserErrors_XML_HTML_UNKNOWN_TAG {
+      // do not record invalid, in fact (out of despair) claim we ARE well-formed, when a tag is invalid.
+      HACKY_WELL_FORMED = true;
+    }
+  }
+}
+#[cfg(not(libxml_older_than_2_12))]
+unsafe extern "C" fn _ignoreInvalidTagsErrorFunc(_user_data: *mut c_void, error: *const xmlError) {
   unsafe {
     if !error.is_null() && (*error).code as u32 == xmlParserErrors_XML_HTML_UNKNOWN_TAG {
       // do not record invalid, in fact (out of despair) claim we ARE well-formed, when a tag is invalid.

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,7 +66,7 @@ impl StructuredError {
   /// This function copies data from the memory `error_ptr` but does not deallocate
   /// the error. Depending on the context in which this function is used, you may
   /// need to take additional steps to avoid a memory leak.
-  pub unsafe fn from_raw(error_ptr: *mut bindings::xmlError) -> Self {
+  pub unsafe fn from_raw(error_ptr: *const bindings::xmlError) -> Self {
     let error = *error_ptr;
     let message = StructuredError::ptr_to_string(error.message);
     let level = XmlErrorLevel::from_raw(error.level);

--- a/src/schemas/common.rs
+++ b/src/schemas/common.rs
@@ -9,7 +9,18 @@ use std::ffi::c_void;
 
 /// Provides a callback to the C side of things to accumulate xmlErrors to be
 /// handled back on the Rust side.
+#[cfg(libxml_older_than_2_12)]
 pub unsafe extern "C" fn structured_error_handler(ctx: *mut c_void, error: bindings::xmlErrorPtr) {
+  assert!(!ctx.is_null());
+  let errlog = unsafe { &mut *{ ctx as *mut Vec<StructuredError> } };
+
+  let error = unsafe { StructuredError::from_raw(error) };
+
+  errlog.push(error);
+}
+
+#[cfg(not(libxml_older_than_2_12))]
+pub unsafe extern "C" fn structured_error_handler(ctx: *mut c_void, error: *const bindings::xmlError) {
   assert!(!ctx.is_null());
   let errlog = unsafe { &mut *{ ctx as *mut Vec<StructuredError> } };
 


### PR DESCRIPTION
Fixes #147.

First, opening the PR just with the added CI job to demonstrate its failure (see [the logs](https://github.com/KWARC/rust-libxml/actions/runs/14570632785/job/40867153540)).
Then, fixing the build by detecting the libxml2 version via pkg-config and adapting the code accordingly.

Note that in my previous PR I generated the `default_bindings.rs` with libxml 2.9.14. We can also revisit this choice later, possibly introducing different default bindings for < 2.12 and for >= 2.12, letting the user select which one via some environment variable. It would also be good to introduce a similar auto-detection logic on Windows via `vcpkg`.