### PR TITLE
Support Mingw-w64, also with CI target

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,13 +4,14 @@ name: CI Windows
 
 jobs:
   test-default-windows:
-    name: Windows default
+    name: Windows vcpkg (default)
     runs-on: windows-latest
     env: 
       VCPKGRS_DYNAMIC: 1
       VCPKG_DEFAULT_TRIPLET: x64-windows
       VCPKG_ROOT: C:\vcpkg
     steps:
+      - uses: actions/checkout@v4
       - name: Setup vcpkg libxml2 Cache
         uses: actions/cache@v4
         id: vcpkg-cache
@@ -19,9 +20,38 @@ jobs:
           key: vcpkg-libxml2
       - name: Install libxml2 with vcpkg
         run: |
-          vcpkg install libxml2
+          vcpkg install libxml2:x64-windows
           vcpkg integrate install
-      - uses: actions/checkout@v2
+      - name: run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  test-mingw64-windows:
+    name: Windows (mingw64)
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: msys2/setup-msys2@v2
+        with:
+          path-type: minimal
+          release: false
+          update: false
+          msystem: MINGW64
+          install: >-
+            mingw64/mingw-w64-x86_64-pkg-config
+            mingw64/mingw-w64-x86_64-libxml2
+      - name: Install stable windows-gnu Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable-x86_64-pc-windows-gnu
+          target: x86_64-pc-windows-gnu
+          override: true
+      - name: Ensure mingw64 pkg-config is in path
+        run: echo "C:\msys64\mingw64\bin" >> "$GITHUB_PATH"
       - name: run tests
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,11 @@ name = "libxml"
 [dependencies]
 libc = "0.2"
 
-[target.'cfg(windows)'.build-dependencies]
+[target.'cfg(all(target_family = "windows", target_env = "msvc"))'.build-dependencies]
 vcpkg = "0.2"
+
+[target.'cfg(all(target_family = "windows", target_env = "gnu"))'.build-dependencies]
+pkg-config = "0.3.2"
 
 [target.'cfg(macos)'.build-dependencies]
 pkg-config = "0.3.2"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ $ pkg install libxml2 pkgconf
 
 ### Windows
 
+#### msvc
+
 [Community contributed](https://github.com/KWARC/rust-libxml/issues/81#issuecomment-760364976):
 
 * manually install builds tools c++ and english language by visiting [BuildTools](https://visualstudio.microsoft.com/fr/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
@@ -56,3 +58,7 @@ C:\> refreshenv
 C:\> vcpkg install libxml2:x64-windows
 C:\> vcpkg integrate install
 ```
+
+#### gnu
+
+On mingw64 environment you could install libxml2 with `pacman -S mingw64/mingw-w64-x86_64-libxml2`.

--- a/build.rs
+++ b/build.rs
@@ -40,7 +40,7 @@ fn find_libxml2() -> Option<ProbedLib> {
     );
     None
   } else {
-    #[cfg(any(target_family = "unix", target_os = "macos"))]
+    #[cfg(any(target_family = "unix", target_os = "macos", all(target_family="windows", target_env="gnu")))]
     {
       let lib = pkg_config::Config::new()
         .probe("libxml-2.0")
@@ -109,7 +109,7 @@ fn main() {
   }
 }
 
-#[cfg(target_family = "windows")]
+#[cfg(all(target_family = "windows", target_env = "msvc"))]
 mod vcpkg_dep {
   use crate::ProbedLib;
   pub fn vcpkg_find_libxml2() -> Option<ProbedLib> {

--- a/build.rs
+++ b/build.rs
@@ -51,7 +51,7 @@ fn find_libxml2() -> Option<ProbedLib> {
       })
     }
 
-    #[cfg(target_family = "windows")]
+    #[cfg(all(target_family = "windows", target_env = "msvc"))]
     {
       if let Some(meta) =  vcpkg_dep::vcpkg_find_libxml2() {
         return Some(meta);
@@ -113,8 +113,9 @@ fn main() {
 mod vcpkg_dep {
   use crate::ProbedLib;
   pub fn vcpkg_find_libxml2() -> Option<ProbedLib> {
-    if let Ok(metadata) = vcpkg::find_package("libxml2") {
-      Some(ProbedLib { version: vcpkg_version(), include_paths: metadata.include_paths })
+    if let Ok(metadata) = vcpkg::Config::new()
+      .find_package("libxml2") {
+      Some(ProbedLib { version: vcpkg_version(), include_paths: dbg!(metadata).include_paths })
     } else {
       None
     }

--- a/build.rs
+++ b/build.rs
@@ -115,7 +115,7 @@ mod vcpkg_dep {
   pub fn vcpkg_find_libxml2() -> Option<ProbedLib> {
     if let Ok(metadata) = vcpkg::Config::new()
       .find_package("libxml2") {
-      Some(ProbedLib { version: vcpkg_version(), include_paths: dbg!(metadata).include_paths })
+      Some(ProbedLib { version: vcpkg_version(), include_paths: metadata.include_paths })
     } else {
       None
     }

--- a/src/c_helpers.rs
+++ b/src/c_helpers.rs
@@ -143,3 +143,18 @@ pub fn xmlXPathObjectNumberOfNodes(val: xmlXPathObjectPtr) -> c_int {
 pub fn xmlXPathObjectGetNodes(val: xmlXPathObjectPtr, size: size_t) -> Vec<xmlNodePtr> {
   unsafe { slice::from_raw_parts((*(*val).nodesetval).nodeTab, size).to_vec() }
 }
+
+#[cfg(any(target_family = "unix", target_os = "macos", all(target_family="windows", target_env="gnu")))]
+pub fn bindgenFree(val: *mut c_void) {
+  unsafe {
+    if let Some(xml_free_fn) = xmlFree {
+      xml_free_fn(val);
+    } else {
+      libc::free(val);
+    }
+  }
+}
+#[cfg(all(target_family="windows", target_env="msvc"))]
+pub fn bindgenFree(val: *mut c_void) {
+  unsafe { libc::free(val as *mut c_void); }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -17,7 +17,7 @@ use std::slice;
 use std::str;
 use std::sync::Once;
 
-static INIT_LIBXML_PARSER: Once = Once::new();
+pub(crate) static INIT_LIBXML_PARSER: Once = Once::new();
 
 enum XmlParserOption {
   Recover = 1,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -17,7 +17,7 @@ use std::slice;
 use std::str;
 use std::sync::Once;
 
-pub(crate) static INIT_LIBXML_PARSER: Once = Once::new();
+static INIT_LIBXML_PARSER: Once = Once::new();
 
 enum XmlParserOption {
   Recover = 1,

--- a/src/readonly/tree.rs
+++ b/src/readonly/tree.rs
@@ -212,9 +212,7 @@ impl RoNode {
     }
     let c_string = unsafe { CStr::from_ptr(content_ptr as *const c_char) };
     let rust_utf8 = c_string.to_string_lossy().into_owned();
-    unsafe {
-      libc::free(content_ptr as *mut c_void);
-    }
+    bindgenFree(content_ptr as *mut c_void);
     rust_utf8
   }
 
@@ -227,10 +225,7 @@ impl RoNode {
     }
     let c_value_string = unsafe { CStr::from_ptr(value_ptr as *const c_char) };
     let prop_str = c_value_string.to_string_lossy().into_owned();
-    // A safe way to free the memory is using libc::free -- I have experienced that xmlFree from libxml2 is not reliable
-    unsafe {
-      libc::free(value_ptr as *mut c_void);
-    }
+    bindgenFree(value_ptr as *mut c_void);
     Some(prop_str)
   }
 
@@ -245,9 +240,7 @@ impl RoNode {
     }
     let c_value_string = unsafe { CStr::from_ptr(value_ptr as *const c_char) };
     let prop_str = c_value_string.to_string_lossy().into_owned();
-    unsafe {
-      libc::free(value_ptr as *mut c_void);
-    }
+    bindgenFree(value_ptr as *mut c_void);
     Some(prop_str)
   }
 
@@ -260,9 +253,7 @@ impl RoNode {
     }
     let c_value_string = unsafe { CStr::from_ptr(value_ptr as *const c_char) };
     let prop_str = c_value_string.to_string_lossy().into_owned();
-    unsafe {
-      libc::free(value_ptr as *mut c_void);
-    }
+    bindgenFree(value_ptr as *mut c_void);
     Some(prop_str)
   }
 

--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -84,9 +84,14 @@ impl fmt::Display for Document {
 impl Document {
   /// Creates a new empty libxml2 document
   pub fn new() -> Result<Self, ()> {
+    // initialize the parser context
+    crate::parser::INIT_LIBXML_PARSER.call_once(|| unsafe {
+      crate::bindings::xmlInitParser();
+    });
     unsafe {
       let c_version = CString::new("1.0").unwrap();
-      let doc_ptr = xmlNewDoc(c_version.as_bytes().as_ptr());
+      let c_version_bytes = c_version.as_bytes();
+      let doc_ptr = xmlNewDoc(c_version_bytes.as_ptr());
       if doc_ptr.is_null() {
         Err(())
       } else {
@@ -290,12 +295,14 @@ impl Document {
   pub fn create_processing_instruction(&mut self, name: &str, content: &str) -> Result<Node, ()> {
     unsafe {
       let c_name = CString::new(name).unwrap();
+      let c_name_bytes = c_name.as_bytes();
       let c_content = CString::new(content).unwrap();
+      let c_content_bytes = c_content.as_bytes();
 
       let node_ptr: xmlNodePtr = xmlNewDocPI(
         self.doc_ptr(),
-        c_name.as_bytes().as_ptr(),
-        c_content.as_bytes().as_ptr(),
+        c_name_bytes.as_ptr(),
+        c_content_bytes.as_ptr(),
       );
       if node_ptr.is_null() {
         Err(())

--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -84,10 +84,6 @@ impl fmt::Display for Document {
 impl Document {
   /// Creates a new empty libxml2 document
   pub fn new() -> Result<Self, ()> {
-    // initialize the parser context
-    crate::parser::INIT_LIBXML_PARSER.call_once(|| unsafe {
-      crate::bindings::xmlInitParser();
-    });
     unsafe {
       let c_version = CString::new("1.0").unwrap();
       let c_version_bytes = c_version.as_bytes();

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -406,9 +406,7 @@ impl Node {
     }
     let c_string = unsafe { CStr::from_ptr(content_ptr as *const c_char) };
     let rust_utf8 = c_string.to_string_lossy().into_owned();
-    unsafe {
-      libc::free(content_ptr as *mut c_void);
-    }
+    bindgenFree(content_ptr as *mut c_void);
     rust_utf8
   }
 
@@ -428,10 +426,7 @@ impl Node {
     }
     let c_value_string = unsafe { CStr::from_ptr(value_ptr as *const c_char) };
     let prop_str = c_value_string.to_string_lossy().into_owned();
-    // A safe way to free the memory is using libc::free -- I have experienced that xmlFree from libxml2 is not reliable
-    unsafe {
-      libc::free(value_ptr as *mut c_void);
-    }
+    bindgenFree(value_ptr as *mut c_void);
     Some(prop_str)
   }
 
@@ -451,9 +446,7 @@ impl Node {
     }
     let c_value_string = unsafe { CStr::from_ptr(value_ptr as *const c_char) };
     let prop_str = c_value_string.to_string_lossy().into_owned();
-    unsafe {
-      libc::free(value_ptr as *mut c_void);
-    }
+    bindgenFree(value_ptr as *mut c_void);
     Some(prop_str)
   }
 
@@ -466,9 +459,7 @@ impl Node {
     }
     let c_value_string = unsafe { CStr::from_ptr(value_ptr as *const c_char) };
     let prop_str = c_value_string.to_string_lossy().into_owned();
-    unsafe {
-      libc::free(value_ptr as *mut c_void);
-    }
+    bindgenFree(value_ptr as *mut c_void);
     Some(prop_str)
   }
 

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -262,9 +262,7 @@ impl Object {
       let value_ptr = unsafe { xmlXPathCastNodeToString(ptr) };
       let c_value_string = unsafe { CStr::from_ptr(value_ptr as *const c_char) };
       let ready_str = c_value_string.to_string_lossy().into_owned();
-      unsafe {
-        libc::free(value_ptr as *mut c_void);
-      }
+      bindgenFree(value_ptr as *mut c_void);
       vec.push(ready_str);
     }
     vec
@@ -279,7 +277,7 @@ impl fmt::Display for Object {
       let receiver = xmlXPathCastToString(self.ptr);
       let c_string = CStr::from_ptr(receiver as *const c_char);
       let rust_string = str::from_utf8(c_string.to_bytes()).unwrap().to_owned();
-      libc::free(receiver as *mut c_void);
+      bindgenFree(receiver as *mut c_void);
       write!(f, "{}", rust_string)
     }
   }
@@ -294,9 +292,7 @@ pub fn is_well_formed_xpath(xpath: &str) -> bool {
   if xml_xpath_comp_expr_ptr.is_null() {
     false
   } else {
-    unsafe {
-      libc::free(xml_xpath_comp_expr_ptr as *mut c_void);
-    }
+    bindgenFree(xml_xpath_comp_expr_ptr as *mut c_void);
     true
   }
 }

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -177,7 +177,7 @@ fn html_fragment() {
   let parser = Parser::default_html();
   let document = parser
     .parse_string_with_options(
-      &fragment,
+      fragment,
       ParserOptions {
         no_def_dtd: true,
         no_implied: true,


### PR DESCRIPTION
This PR is an update and transfer of #134 

It was much harder to stabilize than I anticipated, but this should be good enough for v0.3.5.

If actual Windows developers are reading this at a later date, please feel welcome and encouraged to contribute further improvements to the CI recipe, as well as to the approach for dealing with xmlFree. I don't develop on Windows at all, so this PR was my best effort as an outsider.

The key observation that touches the actual wrapper code is that a few of the bindings-near code paths were not sufficiently portable to work in MinGW, hence they get gradually refactored.

Coming up with a CI recipe was quite difficult, but that was mostly due to my having no experience working in either Windows environment.
