### PR TITLE
Protect schema parsing with a mutex.

### DIFF
--- a/src/schemas/schema.rs
+++ b/src/schemas/schema.rs
@@ -1,11 +1,15 @@
 //!
 //! Wrapping of the Schema (xmlSchema)
 //!
+use std::sync::Mutex;
+
 use super::SchemaParserContext;
 
 use crate::bindings;
 
 use crate::error::StructuredError;
+
+static SCHEMA_MUTEX: Mutex<()> = Mutex::new(());
 
 /// Wrapper on xmlSchema
 pub struct Schema(*mut bindings::_xmlSchema);
@@ -13,8 +17,15 @@ pub struct Schema(*mut bindings::_xmlSchema);
 impl Schema {
   /// Create schema by having a SchemaParserContext do the actual parsing of the schema it was provided
   pub fn from_parser(parser: &mut SchemaParserContext) -> Result<Self, Vec<StructuredError>> {
+    // Wrap the schema initialization with a mutex.
+    // We need to do this because `xmlSchemaParse` is NOT thread-safe.
+    // It isn't thread-safe because `xmlSchemaParse` calls `xmlSchemaInitTypes`
+    // which manipulates shared memory in a thread-unsafe way.
+    let lr = SCHEMA_MUTEX.lock().unwrap();
+    
     let raw = unsafe { bindings::xmlSchemaParse(parser.as_ptr()) };
-
+    
+    drop(lr);
     if raw.is_null() {
       Err(parser.drain_errors())
     } else {

--- a/tests/schema_tests.rs
+++ b/tests/schema_tests.rs
@@ -83,8 +83,7 @@ static INVALID_STOCK_XML: &str = r#"<?xml version="1.0"?>
 //       while it still reliably succeeds single-threaded, new implementation is needed to use
 //       these in a parallel setting.
 #[test]
-fn schema_all_tests() {
-// fn schema_from_string() {
+fn schema_from_string() {
   let xml = Parser::default()
     .parse_string(VALID_NOTE_XML)
     .expect("Expected to be able to parse XML Document from string");
@@ -111,8 +110,10 @@ fn schema_all_tests() {
       panic!("Invalid XML accoding to XSD schema");
     }
   }
-  
-  // fn schema_from_string_generates_errors() {
+}
+
+#[test]
+fn schema_from_string_generates_errors() {
   let xml = Parser::default()
     .parse_string(INVALID_NOTE_XML)
     .expect("Expected to be able to parse XML Document from string");
@@ -138,8 +139,10 @@ fn schema_all_tests() {
       }
     }
   }
+}
 
-  // fn schema_from_string_reports_unique_errors() {
+#[test]
+fn schema_from_string_reports_unique_errors() {
   let xml = Parser::default()
     .parse_string(INVALID_STOCK_XML)
     .expect("Expected to be able to parse XML Document from string");


### PR DESCRIPTION
`xmlSchemaParse` is NOT thread-safe - it calls `xmlSchemaInitTypes` - which manipulates shared memory in a thread-unsafe way.

Another possible solution is to put some sort of thread-safe OnceCell around `xmlSchemaInitTypes` and invoke it ourselves in a thread-safe manner the first time `from_parser` is called.

An alternative 'init-once' approach has been submitted as PR #159.