### PR TITLE
Protect `xmlSchemaInitTypes` from thread-unsafe behaviour.

### DIFF
--- a/src/default_bindings.rs
+++ b/src/default_bindings.rs
@@ -10795,6 +10795,9 @@ unsafe extern "C" {
   pub fn xmlSchemaIsValid(ctxt: xmlSchemaValidCtxtPtr) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+  pub fn xmlSchemaInitTypes();
+}
+unsafe extern "C" {
   pub fn xmlSchemaParse(ctxt: xmlSchemaParserCtxtPtr) -> xmlSchemaPtr;
 }
 unsafe extern "C" {

--- a/src/schemas/schema.rs
+++ b/src/schemas/schema.rs
@@ -1,11 +1,15 @@
 //!
 //! Wrapping of the Schema (xmlSchema)
 //!
+use std::sync::OnceLock;
+
 use super::SchemaParserContext;
 
 use crate::bindings;
 
 use crate::error::StructuredError;
+
+static SCHEMA_TYPES_LOCK: OnceLock<bool> = OnceLock::new();
 
 /// Wrapper on xmlSchema
 pub struct Schema(*mut bindings::_xmlSchema);
@@ -13,6 +17,18 @@ pub struct Schema(*mut bindings::_xmlSchema);
 impl Schema {
   /// Create schema by having a SchemaParserContext do the actual parsing of the schema it was provided
   pub fn from_parser(parser: &mut SchemaParserContext) -> Result<Self, Vec<StructuredError>> {
+
+    // `xmlSchemaParse` calls `xmlSchemaInitTypes`.
+    // `xmlSchemaInitTypes` is a lazy function which is only intended to be
+    // called once for optimization purposes - but libxml2 doesn't do this
+    // in a thread-safe manner.  We wrap the call in a OnceLock so that it
+    // only ever needs to be invoked once - and will do it in a thread-safe
+    // way.
+    let _ = SCHEMA_TYPES_LOCK.get_or_init(|| {
+      unsafe { bindings::xmlSchemaInitTypes() };
+      true
+    });
+
     let raw = unsafe { bindings::xmlSchemaParse(parser.as_ptr()) };
 
     if raw.is_null() {

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -3,4 +3,5 @@
 #include <libxml/xpathInternals.h>
 #include <libxml/xmlsave.h>
 #include <libxml/HTMLparser.h>
+#include <libxml/xmlschemastypes.h>
 #include <libxml/xmlschemas.h>

--- a/tests/schema_tests.rs
+++ b/tests/schema_tests.rs
@@ -83,8 +83,7 @@ static INVALID_STOCK_XML: &str = r#"<?xml version="1.0"?>
 //       while it still reliably succeeds single-threaded, new implementation is needed to use
 //       these in a parallel setting.
 #[test]
-fn schema_all_tests() {
-// fn schema_from_string() {
+fn schema_from_string() {
   let xml = Parser::default()
     .parse_string(VALID_NOTE_XML)
     .expect("Expected to be able to parse XML Document from string");
@@ -111,8 +110,10 @@ fn schema_all_tests() {
       panic!("Invalid XML accoding to XSD schema");
     }
   }
-  
-  // fn schema_from_string_generates_errors() {
+}
+
+#[test]
+fn schema_from_string_generates_errors() {
   let xml = Parser::default()
     .parse_string(INVALID_NOTE_XML)
     .expect("Expected to be able to parse XML Document from string");
@@ -138,8 +139,10 @@ fn schema_all_tests() {
       }
     }
   }
+}
 
-  // fn schema_from_string_reports_unique_errors() {
+#[test]
+fn schema_from_string_reports_unique_errors() {
   let xml = Parser::default()
     .parse_string(INVALID_STOCK_XML)
     .expect("Expected to be able to parse XML Document from string");


### PR DESCRIPTION
`xmlSchemaParse` calls `xmlSchemaInitTypes`.
`xmlSchemaInitTypes` is a lazy function which is only intended to be called once for optimization purposes - but libxml2 doesn't do this in a thread-safe manner.  We wrap the call in a OnceLock so that it only ever needs to be invoked once - and will do it in a thread-safe way.

This is the alternative approach to PR #158.