### PR TITLE
check if libxml2 includes are in a libxml2 subdirectory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libxml"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2024"
 authors = ["Andreas Franzén <andreas@devil.se>", "Deyan Ginev <deyan.ginev@gmail.com>","Jan Frederik Schaefer <j.schaefer@jacobs-university.de>"]
 description = "A Rust wrapper for libxml2 - the XML C parser and toolkit developed for the Gnome project"

--- a/build.rs
+++ b/build.rs
@@ -124,17 +124,19 @@ fn main() {
 mod vcpkg_dep {
   use crate::ProbedLib;
   pub fn vcpkg_find_libxml2() -> Option<ProbedLib> {
-    if let Ok(mut metadata) = vcpkg::Config::new().find_package("libxml2") {
-      if let Some(mut include_path) = metadata.include_paths.pop() {
-        if include_path.join("libxml2").exists() {
-          // libxml2 >= 2.14.5 is in a 'libxml2' subdirectory
-          include_path = include_path.join("libxml2");
-        }
-        return Some(ProbedLib {
-          version: vcpkg_version(),
-          include_paths: vec![include_path],
+    if let Ok(metadata) = vcpkg::Config::new().find_package("libxml2") {
+      let include_paths = metadata
+        .include_paths
+        .into_iter()
+        .fold(Vec::new(), |mut acc, p| {
+          acc.push(p.join("libxml2"));
+          acc.push(p);
+          acc
         });
-      }
+      return Some(ProbedLib {
+        version: vcpkg_version(),
+        include_paths,
+      });
     }
     None
   }


### PR DESCRIPTION
## Issue

With the latest update of libxml2 for Windows (vcpkg) to version 2.14.5, the include path has been moved to a `libxml2` subdirectory.

## Fix

If a `libxml2` subdirectory exists, switch to it. Otherwise, stay with the original include path.

## Note

The latest `cargo fmt` applied some format changes.
