### PR TITLE
Node::new_comment and init_parser guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Change Log
 
-## [0.3.9] (in development)
+## [0.3.10] (in development)
+
+## [0.3.9] (2026-04-22)
+
+### Added
+
+* `Node::new_comment` constructor, wrapping `xmlNewDocComment`. Returns an
+  unlinked comment node bound to the given document; propagates an error
+  rather than panicking on embedded NULs.
+* `libxml::init_parser()`, a top-level safe wrapper around
+  `xmlInitParser()` guarded by `std::sync::Once`. Useful for application
+  code that touches libxml2 directly without going through `parser::Parser`.
+
+### Changes
+
+* `Parser::default()` and `Parser::default_html()` now route through
+  `libxml::init_parser()` instead of their own private `Once`, giving a
+  single source of truth for libxml2 parser initialisation.
 
 ## [0.3.8] (2025-25-09)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libxml"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2024"
 authors = ["Andreas Franzén <andreas@devil.se>", "Deyan Ginev <deyan.ginev@gmail.com>","Jan Frederik Schaefer <j.schaefer@jacobs-university.de>"]
 description = "A Rust wrapper for libxml2 - the XML C parser and toolkit developed for the Gnome project"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,3 +26,19 @@ pub mod schemas;
 
 /// Read-only parallel primitives
 pub mod readonly;
+
+/// Ensure libxml2's global parser state is initialised. Safe to call from
+/// any number of threads — internally guarded by `std::sync::Once` so the
+/// underlying `xmlInitParser()` runs exactly once. Call this before
+/// performing any libxml2 operations from application code that does
+/// *not* go through the `parser::Parser` API (which initialises lazily).
+///
+/// See libxml2's own thread-safety guidance:
+/// <https://dev.w3.org/XInclude-Test-Suite/libxml2-2.4.24/doc/threads.html>
+pub fn init_parser() {
+  use std::sync::Once;
+  static INIT: Once = Once::new();
+  INIT.call_once(|| unsafe {
+    bindings::xmlInitParser();
+  });
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -15,9 +15,6 @@ use std::os::raw::{c_char, c_int};
 use std::ptr;
 use std::slice;
 use std::str;
-use std::sync::Once;
-
-static INIT_LIBXML_PARSER: Once = Once::new();
 
 enum XmlParserOption {
   Recover = 1,
@@ -221,9 +218,7 @@ impl Default for Parser {
   /// Create a parser for XML documents
   fn default() -> Self {
     // avoid deadlocks from using multiple parsers
-    INIT_LIBXML_PARSER.call_once(|| unsafe {
-      crate::bindings::xmlInitParser();
-    });
+    crate::init_parser();
     Parser {
       format: ParseFormat::XML,
     }
@@ -233,9 +228,7 @@ impl Parser {
   /// Create a parser for HTML documents
   pub fn default_html() -> Self {
     // avoid deadlocks from using multiple parsers
-    INIT_LIBXML_PARSER.call_once(|| unsafe {
-      crate::bindings::xmlInitParser();
-    });
+    crate::init_parser();
     Parser {
       format: ParseFormat::HTML,
     }

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -168,6 +168,24 @@ impl Node {
       }
     }
   }
+
+  /// Create a new comment node, bound to a given document. The returned
+  /// node is unlinked — attach it via `add_child`, `add_prev_sibling` or
+  /// `add_next_sibling`.
+  ///
+  /// Returns `Err(())` if the C string cannot be constructed (the comment
+  /// contains an embedded NUL), or if libxml2 returns NULL.
+  pub fn new_comment(content: &str, doc: &Document) -> Result<Self, ()> {
+    let c_content = CString::new(content).map_err(|_| ())?;
+    unsafe {
+      let node = xmlNewDocComment(doc.doc_ptr(), c_content.as_bytes().as_ptr());
+      if node.is_null() {
+        Err(())
+      } else {
+        Ok(Node::wrap_new(node, &doc.0))
+      }
+    }
+  }
   /// Create a mock node, used for a placeholder argument
   pub fn mock(doc: &Document) -> Self {
     Node::new("mock", None, doc).unwrap()

--- a/tests/tree_tests.rs
+++ b/tests/tree_tests.rs
@@ -43,6 +43,27 @@ fn node_sibling_accessors() {
 }
 
 #[test]
+/// Constructing a comment node, attaching it, and serializing it
+fn node_new_comment() {
+  let mut doc = Document::new().unwrap();
+  let mut root = Node::new("root", None, &doc).unwrap();
+  doc.set_root_element(&root);
+
+  let mut comment = Node::new_comment(" hello ", &doc).unwrap();
+  assert_eq!(comment.get_type(), Some(NodeType::CommentNode));
+  assert!(root.add_child(&mut comment).is_ok());
+
+  let serialized = doc.to_string();
+  assert!(
+    serialized.contains("<!-- hello -->"),
+    "expected comment in serialized doc, got: {serialized}"
+  );
+
+  // Embedded NUL should return Err rather than panic.
+  assert!(Node::new_comment("bad\0content", &doc).is_err());
+}
+
+#[test]
 fn node_children_accessors() {
   // Setup
   let parser = Parser::default();


### PR DESCRIPTION
Two small high-level wrappers:

* `Node::new_comment(content, doc)` — mirrors `new_text`, wraps `xmlNewDocComment`. Returns `Err(())` if the content contains a NUL or libxml2 returns NULL. Returned node is unlinked; callers attach via `add_child` / `add_prev_sibling` / `add_next_sibling`.

* `libxml::init_parser()` at the top-level — Once-guarded wrapper around `xmlInitParser`. Safe to call from multiple threads; the underlying C init runs exactly once. Useful for applications that don't go through `Parser::default()` (which already initialises lazily) but still need libxml2 globals available — e.g. when constructing `Document` or `Node` handles directly at startup.


We'll also publish v0.3.9 with this PR.