### PR TITLE
fix(tests): use portable byte type to avoid failing on arm64

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,8 +3,8 @@ on: [push, pull_request]
 name: CI Linux
 
 jobs:
-  test:
-    name: rust-libxml CI
+  test-amd64:
+    name: rust-libxml amd64 CI
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -17,6 +17,25 @@ jobs:
       - name: Set up LIBXML2 env var if compiling with the default bindings
         run: echo "LIBXML2=$(pkg-config libxml-2.0 --variable=libdir)/libxml2.so" >> "$GITHUB_ENV"
         if: ${{ matrix.with_default_bindings }}
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  test-arm64:
+    name: rust-libxml arm64 CI
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: install dependencies
+        uses: ryankurte/action-apt@v0.2.0
+        with:
+          packages: "libxml2-dev"
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/tests/xml_copy_invariant_tests.rs
+++ b/tests/xml_copy_invariant_tests.rs
@@ -453,11 +453,11 @@ fn xml_copy_node_pair_nodict_parse() {
   let xml_bytes = xml.as_bytes();
   unsafe {
     let doc_ptr = xmlReadMemory(
-      xml_bytes.as_ptr() as *const i8,
-      xml_bytes.len() as i32,
+      xml_bytes.as_ptr() as *const ::std::os::raw::c_char,
+      xml_bytes.len() as ::std::os::raw::c_int,
       c"file.xml".as_ptr(),
       std::ptr::null(),
-      xmlParserOption_XML_PARSE_NODICT as i32,
+      xmlParserOption_XML_PARSE_NODICT as ::std::os::raw::c_int,
     );
     assert!(!doc_ptr.is_null(), "xmlReadMemory returned NULL");
     let doc = Document::new_ptr(doc_ptr);


### PR DESCRIPTION
Fixes #196.