### PR TITLE
Document::remove_internal_subset + 0.3.11 CHANGELOG prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [0.3.11] (in development)
+
+### Added
+
+* `Document::remove_internal_subset`, a safe wrapper around
+  `xmlGetIntSubset` + `xmlUnlinkNode` + `xmlFreeDtd`. Mirrors
+  XML::LibXML's `Document::removeInternalSubset` (Perl): drops the
+  internal DTD node so subsequent serialisation no longer emits the
+  `<!DOCTYPE …>` preamble. Idempotent, safe on doctype-less
+  documents.
+
 ## [0.3.10] (2026-05-09)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
-## [0.3.11] (in development)
+## [0.3.12] (in development)
+
+## [0.3.11] (2026-05-18)
 
 ### Added
 
@@ -10,6 +12,22 @@
   internal DTD node so subsequent serialisation no longer emits the
   `<!DOCTYPE …>` preamble. Idempotent, safe on doctype-less
   documents.
+
+### Changes
+
+* Whole-crate clippy pass: `cargo clippy --fix --all-targets` plus
+  manual touch-ups so the workspace builds warning-free on the
+  current stable.
+
+### Fixed
+
+* Test suite portability on ARM64 — switched to portable types in
+  `tests/xml_copy_invariant_tests.rs` so the cross-platform CI run
+  (new arm64 GitHub Actions job) passes alongside x86_64.
+
+### CI
+
+* Added an arm64 build/test job to `.github/workflows/CI.yml`.
 
 ## [0.3.10] (2026-05-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,16 +18,14 @@
 * Whole-crate clippy pass: `cargo clippy --fix --all-targets` plus
   manual touch-ups so the workspace builds warning-free on the
   current stable.
+* Added an arm64 build/test job to `.github/workflows/CI.yml`
+  (thanks @wetneb).
 
 ### Fixed
 
 * Test suite portability on ARM64 — switched to portable types in
   `tests/xml_copy_invariant_tests.rs` so the cross-platform CI run
-  (new arm64 GitHub Actions job) passes alongside x86_64.
-
-### CI
-
-* Added an arm64 build/test job to `.github/workflows/CI.yml`.
+  passes alongside x86_64 (thanks @wetneb).
 
 ## [0.3.10] (2026-05-09)
 

--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -169,6 +169,25 @@ impl Document {
     root.set_linked();
   }
 
+  /// Remove the internal DTD subset (the `<!DOCTYPE …>` declaration)
+  /// from this document, if any. Mirrors XML::LibXML's
+  /// `Document::removeInternalSubset` (Perl) and the effect of
+  /// libxml2's `xmlSetIntSubset(doc, NULL)` — subsequent
+  /// serialisation no longer emits the DOCTYPE preamble.
+  ///
+  /// Safe to call on a document with no internal subset (no-op).
+  /// Unlinks the DTD node from the document and frees it via
+  /// `xmlFreeDtd`.
+  pub fn remove_internal_subset(&mut self) {
+    unsafe {
+      let dtd = xmlGetIntSubset(self.doc_ptr());
+      if !dtd.is_null() {
+        xmlUnlinkNode(dtd as xmlNodePtr);
+        xmlFreeDtd(dtd);
+      }
+    }
+  }
+
   fn ptr_as_result(&mut self, node_ptr: xmlNodePtr) -> Result<Node, ()> {
     if node_ptr.is_null() {
       Err(())

--- a/tests/tree_tests.rs
+++ b/tests/tree_tests.rs
@@ -64,6 +64,54 @@ fn node_new_comment() {
 }
 
 #[test]
+/// `Document::remove_internal_subset` strips the DOCTYPE preamble
+/// from a parsed document, mirroring XML::LibXML's
+/// `removeInternalSubset`.
+fn document_remove_internal_subset() {
+  let parser = Parser::default();
+  let xml = r#"<?xml version="1.0"?>
+<!DOCTYPE root SYSTEM "example.dtd">
+<root><child>hi</child></root>"#;
+  let mut doc = parser.parse_string(xml).expect("parse");
+
+  // Before removal: serialisation includes the DOCTYPE.
+  let before = doc.to_string();
+  assert!(
+    before.contains("<!DOCTYPE"),
+    "expected DOCTYPE in serialized doc before remove, got: {before}"
+  );
+
+  doc.remove_internal_subset();
+
+  // After: no DOCTYPE preamble, root element untouched.
+  let after = doc.to_string();
+  assert!(
+    !after.contains("<!DOCTYPE"),
+    "DOCTYPE still present after remove_internal_subset: {after}"
+  );
+  assert!(after.contains("<root>"));
+  assert!(after.contains("<child>hi</child>"));
+
+  // Idempotent: second call on a subset-less doc is a no-op.
+  doc.remove_internal_subset();
+  let after2 = doc.to_string();
+  assert_eq!(after, after2);
+}
+
+#[test]
+/// `Document::remove_internal_subset` on a doc without a DTD is a no-op.
+fn document_remove_internal_subset_no_doctype_noop() {
+  let parser = Parser::default();
+  let mut doc = parser
+    .parse_string(r#"<?xml version="1.0"?><root/>"#)
+    .expect("parse");
+  let before = doc.to_string();
+  doc.remove_internal_subset();
+  let after = doc.to_string();
+  assert_eq!(before, after);
+}
+
+#[test]
 fn node_children_accessors() {
   // Setup
   let parser = Parser::default();


### PR DESCRIPTION
## Summary

Adds `Document::remove_internal_subset`, a safe wrapper around
`xmlGetIntSubset` + `xmlUnlinkNode` + `xmlFreeDtd`. Mirrors Perl
XML::LibXML's `Document::removeInternalSubset`: drops the
internal DTD node so subsequent serialisation no longer emits the
`<!DOCTYPE …>` preamble. Idempotent, safe on doctype-less
documents.

Motivation: in [`latexml-oxide`](https://github.com/dginev/latexml-oxide)
the `latexml_post::writer::Writer::omit_doctype` field is a port
of Perl `Post::Writer.pm` L38 (`removeInternalSubset if
omit_doctype`) and was dead until this API became available. With
this PR + a bump to `libxml = 0.3.11`, the Writer can honour the
flag faithfully (verified downstream — both writer tests now
exercise the actual DTD strip).

The FFI symbols (`xmlGetIntSubset`, `xmlUnlinkNode`, `xmlFreeDtd`)
were already in `default_bindings.rs`; this PR just adds the safe
wrapper plus two unit tests in `tree_tests.rs`.

A second commit prepares `CHANGELOG.md` for the 0.3.11 release by
pinning today's date and opening a fresh `[0.3.12] (in development)`
section. It also documents the three post-0.3.10 master commits
(clippy pass, arm64 test portability fix, arm64 CI job) alongside
the new `remove_internal_subset` entry.

## Test plan

- [x] `cargo test` — all suites pass (existing + 2 new
  `document_remove_internal_subset*` tests).
- [x] Verified downstream consumption in latexml-oxide via a
  `[patch.crates-io]` override pointing at this branch; tests there
  go from 1326 → 1328 (two new `writer_*omit_doctype*` tests
  exercise the end-to-end Writer.process path).
- [x] `cargo build` clean on stable.