### PR TITLE
fix(node): guard node_ptr_mut with RefCell::try_borrow_mut, not Rc::strong_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Change Log
 
+## [0.3.14] (2026-06-21)
+
+### Changed
+
+* `Node::node_ptr_mut` now guards mutable access with
+  `RefCell::try_borrow_mut` instead of the
+  `Rc::strong_count <= NODE_RC_MAX_GUARD` heuristic. It returns `Err` **only**
+  when the node's cell is *actively* borrowed (a genuine re-entrant aliasing
+  conflict on the same wrapped node); a high `Rc::strong_count` from benign
+  `Node` clones — the owning document's node cache plus caller-held handles —
+  no longer blocks mutation. All clones share one `RefCell`, so
+  `try_borrow_mut` is exactly the per-node exclusion check; the old proxy both
+  false-positived on benign clones and could panic via `borrow_mut` on the very
+  conflict it was meant to catch.
+
+### Fixed
+
+* Spurious `Can not mutably reference a shared Node` errors when mutating a node
+  that merely has several live clones (e.g. large or heavily-shared trees, or
+  any node also held in a caller-side cache). Such mutations now succeed; the
+  error is reserved for real active-borrow re-entrancy.
+
+### Deprecated
+
+* `NODE_RC_MAX_GUARD` and `set_node_rc_guard` are now no-ops, retained only for
+  API compatibility. The strong-count threshold they tuned is no longer
+  consulted by `node_ptr_mut`.
+
 ## [0.3.13] (2026-06-11)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libxml"
-version = "0.3.13"
+version = "0.3.14"
 edition = "2024"
 authors = ["Andreas Franzén <andreas@devil.se>", "Deyan Ginev <deyan.ginev@gmail.com>","Jan Frederik Schaefer <j.schaefer@jacobs-university.de>"]
 description = "A Rust wrapper for libxml2 - the XML C parser and toolkit developed for the Gnome project"

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -7,6 +7,8 @@ pub mod nodetype;
 pub use self::document::{Document, SaveOptions};
 pub(crate) use self::document::{DocumentRef, DocumentWeak};
 pub use self::namespace::Namespace;
-pub use self::node::set_node_rc_guard;
-pub use self::node::{Node, NODE_RC_MAX_GUARD};
+pub use self::node::Node;
+// Deprecated, retained for API compatibility (see their definitions in `node`).
+#[allow(deprecated)]
+pub use self::node::{NODE_RC_MAX_GUARD, set_node_rc_guard};
 pub use self::nodetype::NodeType;

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -17,16 +17,19 @@ use crate::tree::nodetype::NodeType;
 use crate::tree::{Document, DocumentRef, DocumentWeak};
 use crate::xpath::Context;
 
-/// Guard treshold for enforcing runtime mutability checks for Nodes
+/// Deprecated, unused. Formerly the `Rc::strong_count` threshold consulted by
+/// [`Node::node_ptr_mut`]. That heuristic was replaced by a
+/// `RefCell::try_borrow_mut` check (a high clone count is not an aliasing
+/// conflict), so this value is no longer read. Retained only for API
+/// compatibility.
+#[deprecated(note = "no longer used; node_ptr_mut now relies on RefCell::try_borrow_mut")]
 pub static mut NODE_RC_MAX_GUARD: usize = 2;
 
-/// Set the guard value for the max Rc "strong count" allowed for mutable use of a Node
-/// Default is 2
-pub fn set_node_rc_guard(value: usize) {
-  unsafe {
-    NODE_RC_MAX_GUARD = value;
-  }
-}
+/// Deprecated no-op. The strong-count guard it tuned was removed in favor of a
+/// `RefCell::try_borrow_mut` check in [`Node::node_ptr_mut`]; calling this has
+/// no effect. Retained so existing callers continue to compile.
+#[deprecated(note = "no-op: node_ptr_mut now relies on RefCell::try_borrow_mut")]
+pub fn set_node_rc_guard(_value: usize) {}
 
 type NodeRef = Rc<RefCell<_Node>>;
 
@@ -175,26 +178,35 @@ impl Node {
     self.0.borrow().node_ptr
   }
 
-  /// Mutably borrows the underlying libxml2 `xmlNodePtr` pointer
-  /// Also protects against mutability conflicts at runtime.
+  /// Mutably borrows the underlying libxml2 `xmlNodePtr`.
+  ///
+  /// Returns `Err` only when this node's `RefCell` is *actively* borrowed — a
+  /// genuine re-entrant aliasing conflict on the same wrapped node. A high
+  /// `Rc::strong_count` is not a conflict and does not block the borrow: clones
+  /// are normal (the owning document caches one wrapper per node, and callers
+  /// hold their own), and all clones share a single `RefCell`, so
+  /// `try_borrow_mut` is the exact per-node exclusion check. This replaces the
+  /// former `Rc::strong_count <= NODE_RC_MAX_GUARD` heuristic, which rejected
+  /// benign clones and could panic (via `borrow_mut`) on the very conflict it
+  /// was meant to catch.
+  ///
+  /// The shared-`RefCell` invariant holds across clones and repeated accessor
+  /// calls for a node that is **linked** in the tree (both resolve to the cached
+  /// wrapper). It does not extend to an unlinked or imported node: `set_unlinked`
+  /// / `import_node` drop the pointer from the cache (its C node may be freed and
+  /// the address reused), so re-wrapping it afterwards yields an independent
+  /// `RefCell`.
+  ///
+  /// This guards the Rust wrapper, not the C node: mutations through the returned
+  /// raw pointer, and the C node's lifetime, remain the caller's responsibility.
   pub fn node_ptr_mut(&mut self) -> Result<xmlNodePtr, String> {
-    let weak_count = Rc::weak_count(&self.0);
-    let strong_count = Rc::strong_count(&self.0);
-
-    // The basic idea would be to use `Rc::get_mut` to guard against multiple borrows.
-    // However, our approach to bookkeeping nodes implies there is *always* a second Rc reference
-    // in the document.nodes Hash. So rather than use `get_mut` directly, the
-    // correct check would be to have a weak count of 0 and a strong count <=2 (one for self, one for .nodes)
-    let guard_ok = unsafe { weak_count == 0 && strong_count <= NODE_RC_MAX_GUARD };
-    if guard_ok {
-      Ok(self.0.borrow_mut().node_ptr)
-    } else {
-      Err(format!(
-        "Can not mutably reference a shared Node {:?}! Rc: weak count: {:?}; strong count: {:?}",
-        self.get_name(),
-        weak_count,
-        strong_count,
-      ))
+    match self.0.try_borrow_mut() {
+      Ok(inner) => Ok(inner.node_ptr),
+      // Do not touch `self.0` here (e.g. `get_name`): it is actively borrowed,
+      // so any further borrow would panic.
+      Err(_) => {
+        Err("Can not mutably reference a Node that is already actively borrowed".to_string())
+      }
     }
   }
 

--- a/tests/mutability_guards.rs
+++ b/tests/mutability_guards.rs
@@ -1,57 +1,54 @@
 //! Enforce Rust ownership pragmatics for the underlying libxml2 objects
 
 use libxml::parser::Parser;
-use libxml::tree::set_node_rc_guard;
 
+/// Mutating a node that merely has several live `Node` CLONES must SUCCEED.
+///
+/// Clones are the normal state of affairs — the owning document keeps one per
+/// node in its cache, and callers hold their own handles — so a high
+/// `Rc::strong_count` is NOT an aliasing conflict. `Node::node_ptr_mut` now
+/// fails only on an *active* re-entrant borrow (via `RefCell::try_borrow_mut`).
+/// This is the regression guard for the former `strong_count <= guard`
+/// heuristic, which spuriously returned `Err` ("shared Node") for these benign
+/// clones and corrupted otherwise-valid mutations.
 #[test]
-fn ownership_guards() {
-  // Setup
+fn clones_do_not_block_mutation() {
   let parser = Parser::default();
-  let doc_result = parser.parse_file("tests/resources/file01.xml");
-  assert!(doc_result.is_ok());
-  let doc = doc_result.unwrap();
+  let doc = parser.parse_file("tests/resources/file01.xml").unwrap();
   let root = doc.get_root_element().unwrap();
 
+  // Two live clones of the SAME node (Rc strong count >= 3: cache + a + b).
   let mut first_a = root.get_first_element_child().unwrap();
   let first_b = root.get_first_element_child().unwrap();
 
-  assert_eq!(
-    first_a.get_attribute("attribute"),
-    Some(String::from("value"))
-  );
-  assert_eq!(
-    first_b.get_attribute("attribute"),
-    Some(String::from("value"))
-  );
+  assert_eq!(first_a.get_attribute("attribute"), Some(String::from("value")));
+  assert_eq!(first_b.get_attribute("attribute"), Some(String::from("value")));
 
-  // Setting an attribute will fail and return an error, as there are too many Rc references
-  // to the same node (Rc strong count of 3)
-  // see `Node::node_ptr_mut` for details
-  assert!(first_a.set_attribute("attribute", "newa").is_err());
-
-  assert_eq!(
-    first_a.get_attribute("attribute"),
-    Some(String::from("value"))
-  );
-  assert_eq!(
-    first_b.get_attribute("attribute"),
-    Some(String::from("value"))
-  );
-
-  // Try again with guard boosted, which allows the change
-  set_node_rc_guard(3);
-
-  // Setting an attribute will fail and return an error, as there are too many Rc references
-  // to the same node (Rc strong count of 3)
-  // see `Node::node_ptr_mut` for details
+  // Previously this returned Err purely from the clone count; it must now succeed.
   assert!(first_a.set_attribute("attribute", "newa").is_ok());
 
-  assert_eq!(
-    first_a.get_attribute("attribute"),
-    Some(String::from("newa"))
-  );
-  assert_eq!(
-    first_b.get_attribute("attribute"),
-    Some(String::from("newa"))
-  );
+  // Both handles alias the same underlying C node, so both observe the change.
+  assert_eq!(first_a.get_attribute("attribute"), Some(String::from("newa")));
+  assert_eq!(first_b.get_attribute("attribute"), Some(String::from("newa")));
+}
+
+/// The former tuning knob `set_node_rc_guard` is now a deprecated no-op, retained
+/// only for API compatibility. Setting it to a tiny value must NOT re-introduce
+/// the old false-positive (which would have blocked the write below).
+#[test]
+#[allow(deprecated)]
+fn set_node_rc_guard_is_a_noop() {
+  use libxml::tree::set_node_rc_guard;
+
+  let parser = Parser::default();
+  let doc = parser.parse_file("tests/resources/file01.xml").unwrap();
+  let mut node = doc
+    .get_root_element()
+    .unwrap()
+    .get_first_element_child()
+    .unwrap();
+  let _alias = node.clone(); // bump the strong count
+
+  set_node_rc_guard(1); // no effect under the try_borrow_mut regime
+  assert!(node.set_attribute("k", "v").is_ok());
 }


### PR DESCRIPTION
## Summary

`Node::node_ptr_mut` gated mutable access on `Rc::strong_count <= NODE_RC_MAX_GUARD` (default 2). That threshold counts live `Node` **clones**, which is not an aliasing conflict — the owning `Document` caches one wrapper per node (`_wrap`/`ptr_as_option` return a clone of the cached `Rc<RefCell<_Node>>`) and callers hold their own handles, so any non-trivial document exceeds it. The result was spurious `Can not mutably reference a shared Node` errors on perfectly valid documents (deeply-shared trees reach clone counts in the thousands), and `borrow_mut` could still **panic** on the genuine conflict the guard was meant to catch.

All clones of a node share a single `RefCell`, so **`RefCell::try_borrow_mut` is the exact per-node exclusion check**: it returns `Err` only when the node is *actively* borrowed (a real re-entrant aliasing conflict), and never on benign clone count.

## Changes

- `node_ptr_mut` now uses `try_borrow_mut` (same `Result` signature, so no caller changes).
- `NODE_RC_MAX_GUARD` / `set_node_rc_guard` are **deprecated no-ops**, retained for API compatibility; the crate never consults them (`set_node_rc_guard` has an empty body).
- `tests/mutability_guards.rs` rewritten to assert the corrected behavior: benign clones mutate fine, and the deprecated setter has no effect (locks in the no-op).
- Scope/limits documented on `node_ptr_mut`: the shared-`RefCell` invariant holds for **linked** nodes; unlinked/imported nodes are evicted from the cache (`set_unlinked`/`import_node`, intentional vs pointer reuse) and re-wrap to an independent `RefCell` — unchanged from before. This guards the Rust wrapper, not the C node.

## Testing

`cargo test` green; `cargo clippy` clean for the changed code. Verified downstream against a large arXiv→XML corpus (latexml-oxide): the spurious "shared Node" errors disappear with **no regressions** (full downstream suite green), and the former `set_node_rc_guard(8192)` workaround is no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)