### PR TITLE
perf: FxHash node-cache + direct attr-value reads (output-identical, ~28-30% on node-heavy docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Change Log
 
+## [Unreleased]
+
+### Changed
+
+* `Node::_wrap`'s per-document `xmlNodePtr -> Node` cache now hashes pointer keys
+  with a small FxHash-style hasher instead of the default SipHash `RandomState`.
+  The cache is probed on every `Node` wrap (child/sibling walks, XPath results,
+  attribute-node access), and its keys are non-adversarial allocator pointers, so
+  SipHash's DoS resistance buys nothing here. Dependency-free (std `Hasher` only),
+  the map is never iterated so ordering is irrelevant, and behavior is identical.
+  Measured ~28-30% wall reduction on node-heavy XML workloads (large math
+  documents).
+
+### Fixed
+
+* `Node::get_properties` / `get_properties_ns` (and their `get_attributes`
+  aliases) now read each attribute's value directly from the attribute node
+  already in hand (`xmlNodeGetContent`), instead of re-resolving it by name with
+  `xmlGetProp` / `xmlGetNsProp`. The old path re-scanned the whole attribute list
+  (`xmlStrEqual` per entry) and allocated a fresh `CString` for the name on every
+  attribute — quadratic in the attribute count. Same returned map; no behavior
+  change.
+
 ## [0.3.14] (2026-06-21)
 
 ### Changed

--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -16,6 +16,86 @@ use crate::tree::node::Node;
 pub(crate) type DocumentRef = Rc<RefCell<_Document>>;
 pub(crate) type DocumentWeak = Weak<RefCell<_Document>>;
 
+/// Fast, dependency-free hasher for the pointer-keyed `nodes` cache. libxml node
+/// pointers are unique and well-distributed, so SipHash's `RandomState` (the std
+/// default) is wasted work on a map that is probed on EVERY `Node::wrap` /
+/// lookup. This FxHash-style multiply-rotate mixes the address in a couple of
+/// instructions. Internal to the node bookkeeping map; not public API.
+#[derive(Default, Clone, Copy)]
+pub(crate) struct BuildNodePtrHasher;
+impl std::hash::BuildHasher for BuildNodePtrHasher {
+  type Hasher = NodePtrHasher;
+  #[inline]
+  fn build_hasher(&self) -> NodePtrHasher {
+    NodePtrHasher(0)
+  }
+}
+#[doc(hidden)]
+pub(crate) struct NodePtrHasher(u64);
+impl NodePtrHasher {
+  #[inline]
+  fn add(&mut self, i: u64) {
+    self.0 = (self.0.rotate_left(5) ^ i).wrapping_mul(0x517c_c1b7_2722_0a95);
+  }
+}
+impl std::hash::Hasher for NodePtrHasher {
+  #[inline]
+  fn finish(&self) -> u64 {
+    self.0
+  }
+  #[inline]
+  fn write_usize(&mut self, i: usize) {
+    self.add(i as u64);
+  }
+  #[inline]
+  fn write_u64(&mut self, i: u64) {
+    self.add(i);
+  }
+  fn write(&mut self, bytes: &[u8]) {
+    for chunk in bytes.chunks(8) {
+      let mut buf = [0u8; 8];
+      buf[..chunk.len()].copy_from_slice(chunk);
+      self.add(u64::from_le_bytes(buf));
+    }
+  }
+}
+
+/// The `_Document::nodes` bookkeeping map: `xmlNodePtr` → wrapped `Node`, hashed
+/// with [`BuildNodePtrHasher`] rather than the std SipHash default.
+pub(crate) type NodeMap = HashMap<xmlNodePtr, Node, BuildNodePtrHasher>;
+
+#[cfg(test)]
+mod node_ptr_hasher_tests {
+  use super::BuildNodePtrHasher;
+  use std::collections::HashSet;
+  use std::hash::{BuildHasher, Hasher};
+
+  fn hash_ptr(addr: usize) -> u64 {
+    // Mirrors the key path: a thin raw pointer's `Hash` calls `write_usize`.
+    let mut h = BuildNodePtrHasher.build_hasher();
+    h.write_usize(addr);
+    h.finish()
+  }
+
+  #[test]
+  fn deterministic() {
+    assert_eq!(hash_ptr(0x7f00_1234_5000), hash_ptr(0x7f00_1234_5000));
+  }
+
+  #[test]
+  fn no_collisions_on_aligned_allocator_run() {
+    // libxml node structs are large + aligned, so real addresses come in
+    // aligned runs — the case a weak hash would clump. Assert the FxHash
+    // mix keeps 10k such keys collision-free (guards against a degenerate
+    // edit to the algorithm/constant).
+    let base = 0x7f00_0000_0000usize;
+    let mut seen = HashSet::new();
+    for i in 0..10_000usize {
+      assert!(seen.insert(hash_ptr(base + i * 160)), "collision at i={i}");
+    }
+  }
+}
+
 #[derive(Debug, Copy, Clone, Default)]
 /// Save Options for Document
 pub struct SaveOptions {
@@ -42,7 +122,7 @@ pub(crate) struct _Document {
   /// pointer to a libxml document
   pub(crate) doc_ptr: xmlDocPtr,
   /// hashed pointer-to-Node bookkeeping table
-  nodes: HashMap<xmlNodePtr, Node>,
+  nodes: NodeMap,
 }
 
 impl _Document {
@@ -93,7 +173,7 @@ impl Document {
       } else {
         let doc = _Document {
           doc_ptr,
-          nodes: HashMap::new(),
+          nodes: NodeMap::default(),
         };
         Ok(Document(Rc::new(RefCell::new(doc))))
       }
@@ -109,7 +189,7 @@ impl Document {
   pub fn new_ptr(doc_ptr: xmlDocPtr) -> Self {
     let doc = _Document {
       doc_ptr,
-      nodes: HashMap::new(),
+      nodes: NodeMap::default(),
     };
     Document(Rc::new(RefCell::new(doc)))
   }
@@ -117,7 +197,7 @@ impl Document {
   pub(crate) fn null_ref() -> DocumentRef {
     Rc::new(RefCell::new(_Document {
       doc_ptr: ptr::null_mut(),
-      nodes: HashMap::new(),
+      nodes: NodeMap::default(),
     }))
   }
 
@@ -414,7 +494,7 @@ impl Document {
     } else {
       let doc = _Document {
         doc_ptr,
-        nodes: HashMap::new(),
+        nodes: NodeMap::default(),
       };
       Ok(Document(Rc::new(RefCell::new(doc))))
     }

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -325,11 +325,14 @@ impl Node {
       Some(child) => {
         let mut current_node = child;
         while !current_node.is_element_node() {
-          match current_node.get_next_sibling() { Some(sibling) => {
-            current_node = sibling;
-          } _ => {
-            break;
-          }}
+          match current_node.get_next_sibling() {
+            Some(sibling) => {
+              current_node = sibling;
+            }
+            _ => {
+              break;
+            }
+          }
         }
         if current_node.is_element_node() {
           Some(current_node)
@@ -347,11 +350,14 @@ impl Node {
       Some(child) => {
         let mut current_node = child;
         while !current_node.is_element_node() {
-          match current_node.get_prev_sibling() { Some(sibling) => {
-            current_node = sibling;
-          } _ => {
-            break;
-          }}
+          match current_node.get_prev_sibling() {
+            Some(sibling) => {
+              current_node = sibling;
+            }
+            _ => {
+              break;
+            }
+          }
         }
         if current_node.is_element_node() {
           Some(current_node)
@@ -369,11 +375,14 @@ impl Node {
       Some(child) => {
         let mut current_node = child;
         while !current_node.is_element_node() {
-          match current_node.get_next_sibling() { Some(sibling) => {
-            current_node = sibling;
-          } _ => {
-            break;
-          }}
+          match current_node.get_next_sibling() {
+            Some(sibling) => {
+              current_node = sibling;
+            }
+            _ => {
+              break;
+            }
+          }
         }
         if current_node.is_element_node() {
           Some(current_node)
@@ -391,11 +400,14 @@ impl Node {
       Some(child) => {
         let mut current_node = child;
         while !current_node.is_element_node() {
-          match current_node.get_prev_sibling() { Some(sibling) => {
-            current_node = sibling;
-          } _ => {
-            break;
-          }}
+          match current_node.get_prev_sibling() {
+            Some(sibling) => {
+              current_node = sibling;
+            }
+            _ => {
+              break;
+            }
+          }
         }
         if current_node.is_element_node() {
           Some(current_node)
@@ -517,7 +529,9 @@ impl Node {
   /// Sets the text content of this `Node`
   pub fn set_content(&mut self, content: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
     let c_content = CString::new(content).unwrap();
-    unsafe { xmlNodeSetContent(self.node_ptr_mut()?, c_content.as_bytes().as_ptr()); }
+    unsafe {
+      xmlNodeSetContent(self.node_ptr_mut()?, c_content.as_bytes().as_ptr());
+    }
     Ok(())
   }
 
@@ -690,7 +704,8 @@ impl Node {
         } else {
           // Propagate libxml2 failure to remove
           Err(From::from(format!(
-            "libxml2 failed to remove property with status: {remove_prop_status:?}")))
+            "libxml2 failed to remove property with status: {remove_prop_status:?}"
+          )))
         }
       } else {
         // silently no-op if asked to remove a property which is not present
@@ -720,7 +735,8 @@ impl Node {
         } else {
           // Propagate libxml2 failure to remove
           Err(From::from(format!(
-            "libxml2 failed to remove property with status: {remove_prop_status:?}")))
+            "libxml2 failed to remove property with status: {remove_prop_status:?}"
+          )))
         }
       } else {
         // silently no-op if asked to remove a property which is not present
@@ -746,7 +762,8 @@ impl Node {
       } else {
         // Propagate libxml2 failure to remove
         Err(From::from(format!(
-          "libxml2 failed to remove property with status: {remove_prop_status:?}")))
+          "libxml2 failed to remove property with status: {remove_prop_status:?}"
+        )))
       }
     } else {
       // silently no-op if asked to remove a property which is not present
@@ -830,7 +847,12 @@ impl Node {
       let name_ptr = xmlAttrName(current_prop);
       let c_name_string = unsafe { CStr::from_ptr(name_ptr) };
       let name = c_name_string.to_string_lossy().into_owned();
-      let value = self.get_property(&name).unwrap_or_default();
+      // Read the value straight from the attribute node we already hold, rather
+      // than re-resolving it by name: `get_property` calls `xmlGetProp`, which
+      // re-scans the whole attribute list with `xmlStrEqual` and allocates a
+      // fresh `CString` for the name on every call — quadratic over the
+      // attribute count, and a hot path during document build / math parsing.
+      let value = attr_node_value(current_prop);
       attributes.insert(name, value);
       current_prop = xmlNextPropertySibling(current_prop);
     }
@@ -847,15 +869,15 @@ impl Node {
       let name_ptr = xmlAttrName(current_prop);
       let c_name_string = unsafe { CStr::from_ptr(name_ptr) };
       let name = c_name_string.to_string_lossy().into_owned();
+      // Same direct-read optimization as `get_properties`: the value is read
+      // from the attribute node itself, avoiding a by-name `xmlGetNsProp`
+      // re-scan (and a per-attribute `CString` allocation).
+      let value = attr_node_value(current_prop);
       let ns_ptr = xmlAttrNs(current_prop);
       if ns_ptr.is_null() {
-        let value = self.get_property_no_ns(&name).unwrap_or_default();
         attributes.insert((name, None), value);
       } else {
         let ns = Namespace { ns_ptr };
-        let value = self
-          .get_property_ns(&name, &ns.get_href())
-          .unwrap_or_default();
         attributes.insert((name, Some(ns)), value);
       }
       current_prop = xmlNextPropertySibling(current_prop);
@@ -1279,27 +1301,28 @@ impl Node {
       // nothing to do here, already in place
       Ok(old)
     } else if self.get_type() == Some(NodeType::ElementNode) {
-      match old.get_parent() { Some(old_parent) => {
-        if &old_parent == self {
-          // unlink new to be available for insertion
-          new.unlink();
-          // mid-child case
-          old.add_next_sibling(&mut new)?;
-          old.unlink();
-          Ok(old)
-        } else {
-          Err(From::from(format!(
-            "Old node was not a child of {:?} parent. Registered parent is {:?} instead.",
-            self.get_name(),
-            old_parent.get_name()
-          )))
+      match old.get_parent() {
+        Some(old_parent) => {
+          if &old_parent == self {
+            // unlink new to be available for insertion
+            new.unlink();
+            // mid-child case
+            old.add_next_sibling(&mut new)?;
+            old.unlink();
+            Ok(old)
+          } else {
+            Err(From::from(format!(
+              "Old node was not a child of {:?} parent. Registered parent is {:?} instead.",
+              self.get_name(),
+              old_parent.get_name()
+            )))
+          }
         }
-      } _ => {
-        Err(From::from(format!(
+        _ => Err(From::from(format!(
           "Old node was not a child of {:?} parent. No registered parent exists.",
           self.get_name()
-        )))
-      }}
+        ))),
+      }
     } else {
       Err(From::from(
         "Can only call replace_child_node an a NodeType::Element type parent.",
@@ -1327,6 +1350,21 @@ fn node_ancestors(node_ptr: xmlNodePtr) -> Vec<xmlNodePtr> {
 
     parents
   }
+}
+
+/// Read an attribute node's value directly via `xmlNodeGetContent`, freeing the
+/// libxml2-allocated buffer. Equivalent to resolving the attribute by name with
+/// `xmlGetProp`, but without the list re-scan and name `CString` allocation —
+/// the caller already holds the attribute pointer.
+fn attr_node_value(attr: xmlAttrPtr) -> String {
+  let content_ptr = unsafe { xmlNodeGetContent(attr as xmlNodePtr) };
+  if content_ptr.is_null() {
+    return String::new();
+  }
+  let c_string = unsafe { CStr::from_ptr(content_ptr as *const c_char) };
+  let value = c_string.to_string_lossy().into_owned();
+  bindgenFree(content_ptr as *mut c_void);
+  value
 }
 
 mod c14n;


### PR DESCRIPTION
Two dependency-free, output-identical performance improvements to the hot paths
exercised by node/attribute-heavy XML processing (measured downstream in
[latexml-oxide](https://github.com/dginev/latexml-oxide), a Rust port of LaTeXML).
Both are based on the latest `main`.

## 1. `perf(node-cache)`: FxHash-style hasher for the `xmlNodePtr -> Node` map

The internal node-bookkeeping map is probed on every `Node::wrap`/lookup and used
the std `SipHash` `RandomState`. The keys are allocator-chosen `xmlNodePtr`
addresses (not adversarial input), so HashDoS resistance is irrelevant and SipHash
is pure wasted work. Swapping in a dependency-free FxHash-style multiply-rotate
hasher on the pointer key cuts **~28-30% of wall on math/node-heavy documents**
(latexml-oxide: `1510.03361` 19.6s→14.1s, a tikz-cd paper 22.4s→15.7s, across both
conversion phases).

- Zero new dependencies (`std::hash` only).
- The map is never iterated, so losing per-run randomization is a no-op.
- Output-identical.
- Includes a determinism + no-collision regression test.

## 2. `perf(attrs)`: `get_properties` reads values directly from the attr node

`get_properties` / `get_properties_ns` (and the `get_attributes` aliases) looped
over the attribute list but then re-resolved each value **by name** via
`get_property` → `xmlGetProp`, which re-scans the whole attribute list
(`xmlStrEqual` per entry) and allocates a fresh `CString` for the name on every
attribute — quadratic in the attribute count, and pure overhead since the loop
already holds the attribute node pointer.

This reads the value straight from that node with `xmlNodeGetContent` (the same
call `get_content` already uses), via a small `attr_node_value` helper. The
returned map is unchanged; libxml's own attribute-accessor tests pass.

## Validation

`cargo test --release` — all test binaries pass (0 failed), including the new
node-cache determinism test.
