### PR TITLE
Streaming TextReader, checked XPath, node-cache/attr perf, NULL-guard SIGSEGV fixes (→ 0.3.15)

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,7 +1,7 @@
 on:
     push:
         branches:
-            - master
+            - main
 
 name: Publish Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+### Added
+
+* `reader::TextReader` — a safe wrapper over libxml2's `xmlTextReader` pull
+  parser, for processing very large documents one subtree at a time instead of
+  building the whole DOM (a 600 MB file becomes a ~7 GB tree). Methods:
+  `from_file`, `read` / `read_next` (advance / skip-subtree),
+  `node_type` / `is_element` / `depth` / `local_name` / `namespace_uri`,
+  `read_to_next(pred)` (the streamable downward-name XPath subset), and two
+  subtree accessors — `expand()` (borrowed `RoNode`, zero-copy, valid until the
+  next advance) and `expand_to_document()` (an owned, self-contained `Document`
+  copy with namespaces reconciled onto the detached root via
+  `xmlDOMWrapCloneNode` + `xmlReconciliateNs`, so serialization keeps the
+  `xmlns=` declarations and nothing dangles into the source once the reader
+  advances).
+* `xpath::XPathError` and the checked evaluators `Context::evaluate_checked`,
+  `node_evaluate_checked`, `node_evaluate_readonly_checked`, returning
+  `Result<Object, XPathError>`. libxml2 aborts a `//X[predicate]` evaluation
+  (returning NULL) when it materializes more than `XPATH_MAX_NODESET_LENGTH`
+  (10M) intermediate nodes and hits the internal *"growing nodeset hit limit"*
+  on very large documents; the existing thin wrappers collapsed that into a bare
+  `Err(())`. The checked variants snapshot libxml2's structured error (message /
+  code / domain, with `is_nodeset_limit()`) so callers can log or branch on the
+  real cause. The existing `evaluate` / `node_evaluate` / `node_evaluate_readonly`
+  are unchanged (reimplemented as `*_checked(..).map_err(|_| ())`).
+
 ### Changed
 
 * `Node::_wrap`'s per-document `xmlNodePtr -> Node` cache now hashes pointer keys
@@ -22,6 +47,16 @@
   (`xmlStrEqual` per entry) and allocated a fresh `CString` for the name on every
   attribute — quadratic in the attribute count. Same returned map; no behavior
   change.
+
+* Null-guarded the raw-pointer field accessors in `c_helpers` (e.g.
+  `xmlNodeType` reading `.type_` at offset 8): a NULL `xmlNodePtr` reaching an
+  accessor produced a `segfault at 8` that bypassed `catch_unwind`. The
+  accessors now return a benign default for a NULL pointer.
+* Hardened the `CStr::from_ptr` surface in `tree::document` (`to_string` /
+  node / properties / xpath serialization) against `strlen(NULL)`: when
+  libxml2 returns a NULL buffer (e.g. OOM during XSLT serialization of a huge
+  document), the wrappers now yield an empty string instead of dereferencing
+  NULL (`segfault at 0 in libc`).
 
 ## [0.3.14] (2026-06-21)
 

--- a/src/c_helpers.rs
+++ b/src/c_helpers.rs
@@ -12,6 +12,9 @@ use std::slice;
 
 // Taken from Nokogiri (https://github.com/sparklemotion/nokogiri/blob/24bb843327306d2d71e4b2dc337c1e327cbf4516/ext/nokogiri/xml_document.c#L64)
 pub fn xmlNodeRecursivelyRemoveNs(node: xmlNodePtr) {
+  if node.is_null() {
+    return;
+  }
   unsafe {
     let mut property: xmlAttrPtr;
 
@@ -42,57 +45,120 @@ pub fn xmlNodeRecursivelyRemoveNs(node: xmlNodePtr) {
     }
   }
 }
+// Null-safety convention for the field accessors below.
+//
+// Each of these reads a single field out of a libxml2 struct via a raw
+// dereference. A NULL input pointer therefore reads that field's offset off
+// address 0 — e.g. `xmlGetNodeType(NULL)` reads `(*NULL).type_` at offset 8,
+// the exact `segfault at 8` observed in production. A NULL node is a legal,
+// reachable value (a placeholder `Node::null()`, an unlinked/adopted-away
+// wrapper, an empty navigation result), so a raw deref here turns an ordinary
+// "no node" into a hard SIGSEGV that bypasses `catch_unwind` and kills the
+// whole process. Every accessor guards its pointer and returns the natural
+// "absence" sentinel instead (a null pointer, or 0 for the element type, which
+// `NodeType::from_int` maps to `None`). Callers already treat those sentinels
+// as "no node", so this only ever converts a crash into the pre-existing
+// no-node path — never a behavioural change on a valid pointer.
 pub fn xmlGetDoc(cur: xmlNodePtr) -> xmlDocPtr {
+  if cur.is_null() {
+    return ptr::null_mut();
+  }
   unsafe { (*cur).doc }
 }
 pub fn xmlNextNsSibling(ns: xmlNsPtr) -> xmlNsPtr {
+  if ns.is_null() {
+    return ptr::null_mut();
+  }
   unsafe { (*ns).next }
 }
 pub fn xmlNsPrefix(ns: xmlNsPtr) -> *const c_char {
+  if ns.is_null() {
+    return ptr::null();
+  }
   unsafe { (*ns).prefix as *const c_char }
 }
 pub fn xmlNsHref(ns: xmlNsPtr) -> *const c_char {
+  if ns.is_null() {
+    return ptr::null();
+  }
   unsafe { (*ns).href as *const c_char }
 }
 pub fn xmlNodeNsDeclarations(cur: xmlNodePtr) -> xmlNsPtr {
+  if cur.is_null() {
+    return ptr::null_mut();
+  }
   unsafe { (*cur).nsDef }
 }
 pub fn xmlNodeNs(cur: xmlNodePtr) -> xmlNsPtr {
+  if cur.is_null() {
+    return ptr::null_mut();
+  }
   unsafe { (*cur).ns }
 }
 
 pub fn xmlNextPropertySibling(attr: xmlAttrPtr) -> xmlAttrPtr {
+  if attr.is_null() {
+    return ptr::null_mut();
+  }
   unsafe { (*attr).next }
 }
 pub fn xmlAttrName(attr: xmlAttrPtr) -> *const c_char {
+  if attr.is_null() {
+    return ptr::null();
+  }
   unsafe { (*attr).name as *const c_char }
 }
 pub fn xmlAttrNs(attr: xmlAttrPtr) -> xmlNsPtr {
+  if attr.is_null() {
+    return ptr::null_mut();
+  }
   unsafe { (*attr).ns }
 }
 pub fn xmlGetFirstProperty(node: xmlNodePtr) -> xmlAttrPtr {
+  if node.is_null() {
+    return ptr::null_mut();
+  }
   unsafe { (*node).properties }
 }
 pub fn xmlGetNodeType(cur: xmlNodePtr) -> xmlElementType {
+  // 0 is not a valid xmlElementType; `NodeType::from_int(0)` returns `None`.
+  if cur.is_null() {
+    return 0;
+  }
   unsafe { (*cur).type_ }
 }
 
 pub fn xmlGetParent(cur: xmlNodePtr) -> xmlNodePtr {
+  if cur.is_null() {
+    return ptr::null_mut();
+  }
   unsafe { (*cur).parent }
 }
 pub fn xmlGetFirstChild(cur: xmlNodePtr) -> xmlNodePtr {
+  if cur.is_null() {
+    return ptr::null_mut();
+  }
   unsafe { (*cur).children }
 }
 pub fn xmlPrevSibling(cur: xmlNodePtr) -> xmlNodePtr {
+  if cur.is_null() {
+    return ptr::null_mut();
+  }
   unsafe { (*cur).prev }
 }
 
 // helper for tree
 pub fn xmlNextSibling(cur: xmlNodePtr) -> xmlNodePtr {
+  if cur.is_null() {
+    return ptr::null_mut();
+  }
   unsafe { (*cur).next }
 }
 
 pub fn xmlNodeGetName(cur: xmlNodePtr) -> *const c_char {
+  if cur.is_null() {
+    return ptr::null();
+  }
   unsafe { (*cur).name as *const c_char }
 }
 
@@ -100,7 +166,8 @@ pub fn xmlNodeGetName(cur: xmlNodePtr) -> *const c_char {
 #[cfg(libxml_older_than_2_12)]
 unsafe extern "C" fn _ignoreInvalidTagsErrorFunc(_user_data: *mut c_void, error: xmlErrorPtr) {
   unsafe {
-    if !error.is_null() && (*error).code as xmlParserErrors == xmlParserErrors_XML_HTML_UNKNOWN_TAG {
+    if !error.is_null() && (*error).code as xmlParserErrors == xmlParserErrors_XML_HTML_UNKNOWN_TAG
+    {
       // do not record invalid, in fact (out of despair) claim we ARE well-formed, when a tag is invalid.
       HACKY_WELL_FORMED = true;
     }
@@ -109,7 +176,8 @@ unsafe extern "C" fn _ignoreInvalidTagsErrorFunc(_user_data: *mut c_void, error:
 #[cfg(not(libxml_older_than_2_12))]
 unsafe extern "C" fn _ignoreInvalidTagsErrorFunc(_user_data: *mut c_void, error: *const xmlError) {
   unsafe {
-    if !error.is_null() && (*error).code as xmlParserErrors == xmlParserErrors_XML_HTML_UNKNOWN_TAG {
+    if !error.is_null() && (*error).code as xmlParserErrors == xmlParserErrors_XML_HTML_UNKNOWN_TAG
+    {
       // do not record invalid, in fact (out of despair) claim we ARE well-formed, when a tag is invalid.
       HACKY_WELL_FORMED = true;
     }
@@ -141,10 +209,21 @@ pub fn xmlXPathObjectNumberOfNodes(val: xmlXPathObjectPtr) -> c_int {
 }
 
 pub fn xmlXPathObjectGetNodes(val: xmlXPathObjectPtr, size: size_t) -> Vec<xmlNodePtr> {
-  unsafe { slice::from_raw_parts((*(*val).nodesetval).nodeTab, size).to_vec() }
+  unsafe {
+    // Guard both the object and its node-set: a NULL either way (empty/failed
+    // XPath) would deref off address 0 rather than yield an empty result.
+    if val.is_null() || (*val).nodesetval.is_null() {
+      return Vec::new();
+    }
+    slice::from_raw_parts((*(*val).nodesetval).nodeTab, size).to_vec()
+  }
 }
 
-#[cfg(any(target_family = "unix", target_os = "macos", all(target_family="windows", target_env="gnu")))]
+#[cfg(any(
+  target_family = "unix",
+  target_os = "macos",
+  all(target_family = "windows", target_env = "gnu")
+))]
 pub fn bindgenFree(val: *mut c_void) {
   unsafe {
     if let Some(xml_free_fn) = xmlFree {
@@ -154,7 +233,9 @@ pub fn bindgenFree(val: *mut c_void) {
     }
   }
 }
-#[cfg(all(target_family="windows", target_env="msvc"))]
+#[cfg(all(target_family = "windows", target_env = "msvc"))]
 pub fn bindgenFree(val: *mut c_void) {
-  unsafe { libc::free(val as *mut c_void); }
+  unsafe {
+    libc::free(val as *mut c_void);
+  }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 //!
 use super::bindings;
 
-use std::ffi::{c_char, c_int, CStr};
+use std::ffi::{CStr, c_char, c_int};
 
 /// Rust enum variant of libxml2's xmlErrorLevel
 #[derive(Debug)]
@@ -57,49 +57,54 @@ pub struct StructuredError {
 
 impl StructuredError {
   /// Copies the error information stored at `error_ptr` into a new `StructuredError`
-  /// 
+  ///
   /// # Safety
   /// This function must be given a pointer to a valid `xmlError` struct. Typically, you
   /// will acquire such a pointer by implementing one of a number of callbacks
   /// defined in libXml which are provided an `xmlError` as an argument.
-  /// 
+  ///
   /// This function copies data from the memory `error_ptr` but does not deallocate
   /// the error. Depending on the context in which this function is used, you may
   /// need to take additional steps to avoid a memory leak.
-  pub unsafe fn from_raw(error_ptr: *const bindings::xmlError) -> Self { unsafe {
-    let error = *error_ptr;
-    let message = StructuredError::ptr_to_string(error.message);
-    let level = XmlErrorLevel::from_raw(error.level);
-    let filename = StructuredError::ptr_to_string(error.file);
+  pub unsafe fn from_raw(error_ptr: *const bindings::xmlError) -> Self {
+    unsafe {
+      let error = *error_ptr;
+      let message = StructuredError::ptr_to_string(error.message);
+      let level = XmlErrorLevel::from_raw(error.level);
+      let filename = StructuredError::ptr_to_string(error.file);
 
-    let line = if error.line == 0 {
-      None
-    } else {
-      Some(error.line)
-    };
-    let col = if error.int2 == 0 {
-      None
-    } else {
-      Some(error.int2)
-    };
+      let line = if error.line == 0 {
+        None
+      } else {
+        Some(error.line)
+      };
+      let col = if error.int2 == 0 {
+        None
+      } else {
+        Some(error.int2)
+      };
 
-    StructuredError {
-      message,
-      level,
-      filename,
-      line,
-      col,
-      domain: error.domain,
-      code: error.code,
+      StructuredError {
+        message,
+        level,
+        filename,
+        line,
+        col,
+        domain: error.domain,
+        code: error.code,
+      }
     }
-  }}
+  }
 
   /// Human-readable informative error message.
-  /// 
+  ///
   /// This function is a hold-over from the original bindings to libxml's error
-  /// reporting mechanism. Instead of calling this method, you can access the 
+  /// reporting mechanism. Instead of calling this method, you can access the
   /// StructuredError `message` field directly.
-  #[deprecated(since="0.3.3", note="Please use the `message` field directly instead.")]
+  #[deprecated(
+    since = "0.3.3",
+    note = "Please use the `message` field directly instead."
+  )]
   pub fn message(&self) -> &str {
     self.message.as_deref().unwrap_or("")
   }

--- a/src/io.rs
+++ b/src/io.rs
@@ -48,7 +48,7 @@ type OpenFn = Box<dyn Fn(&str) -> Option<Vec<u8>> + Send + Sync + 'static>;
 
 struct Callback {
   match_url: MatchFn,
-  open:      OpenFn,
+  open: OpenFn,
 }
 
 fn callbacks() -> &'static Mutex<Vec<Arc<Callback>>> {
@@ -102,7 +102,7 @@ where
 {
   callbacks().lock().unwrap().push(Arc::new(Callback {
     match_url: Box::new(match_url),
-    open:      Box::new(open),
+    open: Box::new(open),
   }));
 
   // libxml2 records the trampoline pointers in a static table;
@@ -125,7 +125,7 @@ where
 /// Per-open state owned by libxml2 via `*mut c_void` until
 /// `trampoline_close` reclaims and drops it.
 struct OpenState {
-  bytes:    Vec<u8>,
+  bytes: Vec<u8>,
   position: usize,
 }
 
@@ -251,7 +251,9 @@ mod tests {
 
     // 3. Unrelated URLs aren't claimed by our match — they reach the
     //    default file handler and fail there.
-    assert!(!read_file_via_libxml2("/nonexistent/definitely/missing.xml"));
+    assert!(!read_file_via_libxml2(
+      "/nonexistent/definitely/missing.xml"
+    ));
 
     // 4. Re-entrancy: an `open` closure that calls into libxml2 must
     //    not self-deadlock on the registry mutex.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,10 @@ pub mod schemas;
 /// Read-only parallel primitives
 pub mod readonly;
 
+/// Streaming pull-parser (`xmlTextReader`) for very large documents — process
+/// one subtree at a time instead of building the whole DOM.
+pub mod reader;
+
 /// Custom input callbacks for `xmlRegisterInputCallbacks` — bundle
 /// XSLT stylesheets / RNG schemas inside the binary and serve them
 /// through a user-defined URL scheme (e.g. `embed:///foo.xsl`).

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -167,25 +167,29 @@ fn xml_open(filename: &str) -> io::Result<*mut c_void> {
 }
 
 /// Read callback for an FS file.
-unsafe extern "C" fn xml_read(context: *mut c_void, buffer: *mut c_char, len: c_int) -> c_int { unsafe {
-  // Len is always positive, typically 40-4000 bytes.
-  let file = context as *mut fs::File;
-  let buf = slice::from_raw_parts_mut(buffer as *mut u8, len as usize);
-  match io::Read::read(&mut *file, buf) {
-    Ok(v) => v as c_int,
-    Err(_) => -1,
+unsafe extern "C" fn xml_read(context: *mut c_void, buffer: *mut c_char, len: c_int) -> c_int {
+  unsafe {
+    // Len is always positive, typically 40-4000 bytes.
+    let file = context as *mut fs::File;
+    let buf = slice::from_raw_parts_mut(buffer as *mut u8, len as usize);
+    match io::Read::read(&mut *file, buf) {
+      Ok(v) => v as c_int,
+      Err(_) => -1,
+    }
   }
-}}
+}
 
 type XmlReadCallback = unsafe extern "C" fn(*mut c_void, *mut c_char, c_int) -> c_int;
 
 /// Close callback for an FS file.
-unsafe extern "C" fn xml_close(context: *mut c_void) -> c_int { unsafe {
-  // Take rust ownership of the context and then drop it.
-  let file = context as *mut fs::File;
-  let _ = Box::from_raw(file);
-  0
-}}
+unsafe extern "C" fn xml_close(context: *mut c_void) -> c_int {
+  unsafe {
+    // Take rust ownership of the context and then drop it.
+    let file = context as *mut fs::File;
+    let _ = Box::from_raw(file);
+    0
+  }
+}
 
 type XmlCloseCallback = unsafe extern "C" fn(*mut c_void) -> c_int;
 
@@ -389,7 +393,7 @@ impl Parser {
           if !docptr.is_null() {
             let node_ptr = xmlDocGetRootElement(docptr);
             if node_ptr.is_null() {
-              return false
+              return false;
             }
             let name_ptr = xmlNodeGetName(node_ptr);
             if name_ptr.is_null() {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -58,6 +58,16 @@ fn const_xmlchar_to_string(ptr: *const xmlChar) -> Option<String> {
   )
 }
 
+/// Map libxml2's reader-advance status (`1` = positioned on a node, `0` = end
+/// of input, negative = parse error) to a `Result`.
+fn read_status(rc: i32) -> Result<bool, ()> {
+  match rc {
+    1 => Ok(true),
+    0 => Ok(false),
+    _ => Err(()),
+  }
+}
+
 impl TextReader {
   /// Open `path` for streaming. `options` is the libxml2 parser-option bitmask
   /// (`0` for defaults). Fails if the reader could not be created (e.g. the
@@ -77,11 +87,7 @@ impl TextReader {
   /// `Ok(true)` = positioned on a node, `Ok(false)` = end of input,
   /// `Err(())` = a parse error occurred.
   pub fn read(&mut self) -> Result<bool, ()> {
-    match unsafe { xmlTextReaderRead(self.ptr) } {
-      1 => Ok(true),
-      0 => Ok(false),
-      _ => Err(()),
-    }
+    read_status(unsafe { xmlTextReaderRead(self.ptr) })
   }
 
   /// Advance to the next node that is **not** a descendant of the current node
@@ -89,11 +95,7 @@ impl TextReader {
   /// past it without walking its children. Same `Ok(true/false)`/`Err`
   /// semantics as [`read`](Self::read).
   pub fn read_next(&mut self) -> Result<bool, ()> {
-    match unsafe { xmlTextReaderNext(self.ptr) } {
-      1 => Ok(true),
-      0 => Ok(false),
-      _ => Err(()),
-    }
+    read_status(unsafe { xmlTextReaderNext(self.ptr) })
   }
 
   /// The current node's type. Returns `None` for reader events that have no
@@ -108,10 +110,14 @@ impl TextReader {
   }
 
   /// True when positioned on an element *start* tag.
-  pub fn is_element(&self) -> bool { self.node_type() == Some(NodeType::ElementNode) }
+  pub fn is_element(&self) -> bool {
+    self.node_type() == Some(NodeType::ElementNode)
+  }
 
   /// The current node's depth in the tree (root element = 0).
-  pub fn depth(&self) -> i32 { unsafe { xmlTextReaderDepth(self.ptr) } }
+  pub fn depth(&self) -> i32 {
+    unsafe { xmlTextReaderDepth(self.ptr) }
+  }
 
   /// The current node's local name (no namespace prefix), if any.
   pub fn local_name(&self) -> Option<String> {
@@ -131,12 +137,16 @@ impl TextReader {
   /// [`expand_to_document`](Self::expand_to_document). Returns `None` at end of
   /// input or on error.
   pub fn expand(&self) -> Option<RoNode> {
+    self.current_subtree().map(RoNode)
+  }
+
+  /// The current node's fully-built subtree as a raw pointer, or `None` at end
+  /// of input / on error. Borrowed from the reader — invalidated by the next
+  /// advance; callers must copy (see [`expand_to_document`](Self::expand_to_document))
+  /// to outlive it.
+  fn current_subtree(&self) -> Option<xmlNodePtr> {
     let node = unsafe { xmlTextReaderExpand(self.ptr) };
-    if node.is_null() {
-      None
-    } else {
-      Some(RoNode(node))
-    }
+    (!node.is_null()).then_some(node)
   }
 
   /// Copy the current node's subtree into a fresh, independently-owned
@@ -148,27 +158,26 @@ impl TextReader {
   /// mutate, transform and serialize after the reader has advanced and freed
   /// its own copy of the subtree. Returns `None` at end of input or on error.
   pub fn expand_to_document(&self) -> Option<Document> {
-    let node = unsafe { xmlTextReaderExpand(self.ptr) };
-    if node.is_null() {
-      return None;
-    }
+    let node = self.current_subtree()?;
     unsafe {
       let newdoc = xmlNewDoc(c"1.0".as_ptr() as *const xmlChar);
       if newdoc.is_null() {
         return None;
       }
-      // xmlDOMWrapCloneNode (unlike xmlDocCopyNode) reconciles namespaces from
-      // the source ancestors onto the clone, so the detached subtree does not
-      // dangle into the source document once the reader frees it. A wrap
-      // context is required for the reconciliation to actually *declare* the
-      // in-scope namespaces on the clone (with a NULL context the clone keeps
-      // an ns pointer but the `xmlns=` decl is not materialized, so
-      // serialization silently drops it).
+      // xmlDOMWrapCloneNode (unlike xmlDocCopyNode) reconciles the source
+      // ancestors' in-scope namespaces onto the clone, so it doesn't dangle
+      // into the source once the reader frees it. The wrap context is
+      // required: with a NULL context the clone keeps an ns *pointer* but the
+      // `xmlns=` decl is never materialized, so serialization silently drops it.
       let ctxt = xmlDOMWrapNewCtxt();
       let mut cloned: xmlNodePtr = ptr::null_mut();
       let src_doc = (*node).doc;
       let rc = xmlDOMWrapCloneNode(
-        ctxt, src_doc, node, &mut cloned, newdoc,
+        ctxt,
+        src_doc,
+        node,
+        &mut cloned,
+        newdoc,
         ptr::null_mut(), // no destination parent — it becomes the root
         1,               // deep
         0,               // options
@@ -220,7 +229,10 @@ mod tests {
   const NS: &str = "http://example.org/ns";
 
   fn write_temp(name: &str, xml: &str) -> String {
-    let path = std::env::temp_dir().join(format!("rust-libxml-reader-{}-{name}.xml", std::process::id()));
+    let path = std::env::temp_dir().join(format!(
+      "rust-libxml-reader-{}-{name}.xml",
+      std::process::id()
+    ));
     std::fs::write(&path, xml).unwrap();
     path.to_string_lossy().into_owned()
   }
@@ -265,13 +277,22 @@ mod tests {
 
     // Serialization is intact and namespace-declared (no dangling ns → no UAF).
     let s0 = sections[0].to_string();
-    assert!(s0.contains("http://example.org/ns"), "ns decl missing: {s0}");
-    assert!(s0.contains("Alpha") && s0.contains("one"), "content lost: {s0}");
+    assert!(
+      s0.contains("http://example.org/ns"),
+      "ns decl missing: {s0}"
+    );
+    assert!(
+      s0.contains("Alpha") && s0.contains("one"),
+      "content lost: {s0}"
+    );
 
     // The second section keeps its prefixed namespace too.
     let s1 = sections[1].to_string();
     assert!(s1.contains("Beta"), "content lost: {s1}");
-    assert!(s1.contains("http://example.org/x"), "prefixed ns lost: {s1}");
+    assert!(
+      s1.contains("http://example.org/x"),
+      "prefixed ns lost: {s1}"
+    );
 
     std::fs::remove_file(&path).ok();
   }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,0 +1,300 @@
+//! Streaming pull-parser (`xmlTextReader`).
+//!
+//! Building the whole DOM for a very large document is prohibitively
+//! memory-hungry (a 600 MB file becomes a ~7 GB tree). [`TextReader`] instead
+//! streams the input node-by-node and lets callers materialize only the
+//! subtrees they care about, so peak memory is one subtree at a time rather
+//! than the entire tree.
+//!
+//! Two ways to materialize the current subtree:
+//! * [`TextReader::expand`] — a **borrowed** [`RoNode`], zero-copy, valid only
+//!   until the next [`read`](TextReader::read)/[`read_next`](TextReader::read_next).
+//!   Ideal for read-only scanning.
+//! * [`TextReader::expand_to_document`] — an **owned** [`Document`] copy
+//!   (namespaces reconciled), safe to hold, mutate, transform and free after
+//!   the reader has advanced. This is the unit the rest of the pipeline
+//!   (XSLT, serialization) consumes.
+//!
+//! ## Streaming a pattern
+//!
+//! libxml2's XPath engine is not streamable (it needs a fully-built tree). The
+//! streamable subset is "downward" name/descendant matching, which at the
+//! reader level is simply a per-element name/namespace test — see
+//! [`TextReader::read_to_next`]. Arbitrary predicates are then applied on the
+//! small owned subtree, where XPath is limit-safe.
+
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+use std::ptr;
+
+use crate::bindings::*;
+use crate::readonly::RoNode;
+use crate::tree::{Document, NodeType};
+
+/// A safe wrapper over libxml2's `xmlTextReader` pull parser.
+///
+/// Owns the underlying reader (and the file handle it opened); dropping the
+/// `TextReader` frees both.
+pub struct TextReader {
+  ptr: xmlTextReaderPtr,
+}
+
+impl Drop for TextReader {
+  fn drop(&mut self) {
+    unsafe { xmlFreeTextReader(self.ptr) };
+  }
+}
+
+/// Borrow a reader-owned `const xmlChar*` (never freed by the caller) as an
+/// owned `String`. Returns `None` for a NULL pointer.
+fn const_xmlchar_to_string(ptr: *const xmlChar) -> Option<String> {
+  if ptr.is_null() {
+    return None;
+  }
+  Some(
+    unsafe { CStr::from_ptr(ptr as *const c_char) }
+      .to_string_lossy()
+      .into_owned(),
+  )
+}
+
+impl TextReader {
+  /// Open `path` for streaming. `options` is the libxml2 parser-option bitmask
+  /// (`0` for defaults). Fails if the reader could not be created (e.g. the
+  /// file does not exist).
+  pub fn from_file(path: &str, options: i32) -> Result<Self, ()> {
+    let c_path = CString::new(path).map_err(|_| ())?;
+    let ptr = unsafe { xmlReaderForFile(c_path.as_ptr(), ptr::null(), options) };
+    if ptr.is_null() {
+      Err(())
+    } else {
+      Ok(TextReader { ptr })
+    }
+  }
+
+  /// Advance to the next node in document order (descending into children).
+  ///
+  /// `Ok(true)` = positioned on a node, `Ok(false)` = end of input,
+  /// `Err(())` = a parse error occurred.
+  pub fn read(&mut self) -> Result<bool, ()> {
+    match unsafe { xmlTextReaderRead(self.ptr) } {
+      1 => Ok(true),
+      0 => Ok(false),
+      _ => Err(()),
+    }
+  }
+
+  /// Advance to the next node that is **not** a descendant of the current node
+  /// (i.e. skip the current subtree). Use after materializing a subtree to move
+  /// past it without walking its children. Same `Ok(true/false)`/`Err`
+  /// semantics as [`read`](Self::read).
+  pub fn read_next(&mut self) -> Result<bool, ()> {
+    match unsafe { xmlTextReaderNext(self.ptr) } {
+      1 => Ok(true),
+      0 => Ok(false),
+      _ => Err(()),
+    }
+  }
+
+  /// The current node's type. Returns `None` for reader events that have no
+  /// [`NodeType`] equivalent — most usefully the *end-of-element* event, which
+  /// lets a caller distinguish an opening `<x>` (`Some(ElementNode)`) from a
+  /// closing `</x>`.
+  pub fn node_type(&self) -> Option<NodeType> {
+    // xmlTextReaderNodeType returns an xmlReaderTypes value; for the shared
+    // cases (element/text/PI/comment/cdata) it is numerically identical to the
+    // xmlElementType NodeType::from_int expects.
+    NodeType::from_int(unsafe { xmlTextReaderNodeType(self.ptr) } as xmlElementType)
+  }
+
+  /// True when positioned on an element *start* tag.
+  pub fn is_element(&self) -> bool { self.node_type() == Some(NodeType::ElementNode) }
+
+  /// The current node's depth in the tree (root element = 0).
+  pub fn depth(&self) -> i32 { unsafe { xmlTextReaderDepth(self.ptr) } }
+
+  /// The current node's local name (no namespace prefix), if any.
+  pub fn local_name(&self) -> Option<String> {
+    const_xmlchar_to_string(unsafe { xmlTextReaderConstLocalName(self.ptr) })
+  }
+
+  /// The current node's namespace URI, if any.
+  pub fn namespace_uri(&self) -> Option<String> {
+    const_xmlchar_to_string(unsafe { xmlTextReaderConstNamespaceUri(self.ptr) })
+  }
+
+  /// Fully build the current node's subtree and borrow it read-only.
+  ///
+  /// Zero-copy. **The returned [`RoNode`] is owned by the reader and is
+  /// invalidated by the next [`read`](Self::read)/[`read_next`](Self::read_next)** — do
+  /// not retain it across an advance. For a subtree you can keep, use
+  /// [`expand_to_document`](Self::expand_to_document). Returns `None` at end of
+  /// input or on error.
+  pub fn expand(&self) -> Option<RoNode> {
+    let node = unsafe { xmlTextReaderExpand(self.ptr) };
+    if node.is_null() {
+      None
+    } else {
+      Some(RoNode(node))
+    }
+  }
+
+  /// Copy the current node's subtree into a fresh, independently-owned
+  /// [`Document`] whose root element is the copy.
+  ///
+  /// Namespaces declared on un-copied ancestors (e.g. the default `xmlns` on
+  /// the real document root) are reconciled onto the copy via
+  /// `xmlDOMWrapCloneNode`, so the result is self-contained — safe to hold,
+  /// mutate, transform and serialize after the reader has advanced and freed
+  /// its own copy of the subtree. Returns `None` at end of input or on error.
+  pub fn expand_to_document(&self) -> Option<Document> {
+    let node = unsafe { xmlTextReaderExpand(self.ptr) };
+    if node.is_null() {
+      return None;
+    }
+    unsafe {
+      let newdoc = xmlNewDoc(c"1.0".as_ptr() as *const xmlChar);
+      if newdoc.is_null() {
+        return None;
+      }
+      // xmlDOMWrapCloneNode (unlike xmlDocCopyNode) reconciles namespaces from
+      // the source ancestors onto the clone, so the detached subtree does not
+      // dangle into the source document once the reader frees it. A wrap
+      // context is required for the reconciliation to actually *declare* the
+      // in-scope namespaces on the clone (with a NULL context the clone keeps
+      // an ns pointer but the `xmlns=` decl is not materialized, so
+      // serialization silently drops it).
+      let ctxt = xmlDOMWrapNewCtxt();
+      let mut cloned: xmlNodePtr = ptr::null_mut();
+      let src_doc = (*node).doc;
+      let rc = xmlDOMWrapCloneNode(
+        ctxt, src_doc, node, &mut cloned, newdoc,
+        ptr::null_mut(), // no destination parent — it becomes the root
+        1,               // deep
+        0,               // options
+      );
+      xmlDOMWrapFreeCtxt(ctxt);
+      if rc != 0 || cloned.is_null() {
+        xmlFreeDoc(newdoc);
+        return None;
+      }
+      xmlDocSetRootElement(newdoc, cloned);
+      // Belt-and-suspenders: ensure every namespace used in the detached tree
+      // is declared within it (self-contained serialization, no dangling ns).
+      xmlReconciliateNs(newdoc, cloned);
+      Some(Document::new_ptr(newdoc))
+    }
+  }
+
+  /// Advance until positioned on the next element whose `(namespace, localname)`
+  /// satisfies `want`, or the end of input.
+  ///
+  /// This is the streaming analogue of a downward `//name` XPath step: the only
+  /// XPath subset that is actually streamable. Returns `Ok(true)` when
+  /// positioned on a match (then call [`expand`](Self::expand) /
+  /// [`expand_to_document`](Self::expand_to_document), and
+  /// [`read_next`](Self::read_next) to skip past it), `Ok(false)` at end of input.
+  ///
+  /// `want` receives the namespace URI (`None` if the element is in no
+  /// namespace) and the local name.
+  pub fn read_to_next<F>(&mut self, want: F) -> Result<bool, ()>
+  where
+    F: Fn(Option<&str>, &str) -> bool,
+  {
+    while self.read()? {
+      if self.is_element()
+        && let Some(name) = self.local_name()
+        && want(self.namespace_uri().as_deref(), &name)
+      {
+        return Ok(true);
+      }
+    }
+    Ok(false)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  const NS: &str = "http://example.org/ns";
+
+  fn write_temp(name: &str, xml: &str) -> String {
+    let path = std::env::temp_dir().join(format!("rust-libxml-reader-{}-{name}.xml", std::process::id()));
+    std::fs::write(&path, xml).unwrap();
+    path.to_string_lossy().into_owned()
+  }
+
+  /// Stream a multi-section document, collect each `<section>` as an owned
+  /// Document, and verify — crucially, *after the reader is dropped* — that the
+  /// copies are self-contained: namespaces inherited from the (un-copied) root
+  /// are reconciled onto each copy, and content survives.
+  #[test]
+  fn stream_sections_owned_and_namespace_reconciled() {
+    let xml = r#"<?xml version="1.0"?>
+<doc xmlns="http://example.org/ns" xmlns:x="http://example.org/x">
+  <meta>skip me</meta>
+  <section id="a"><title>Alpha</title><p>one</p></section>
+  <section id="b"><title>Beta</title><x:note>hi</x:note></section>
+</doc>"#;
+    let path = write_temp("sections", xml);
+
+    let mut sections = Vec::new();
+    {
+      let mut reader = TextReader::from_file(&path, 0).unwrap();
+      while reader
+        .read_to_next(|ns, name| ns == Some(NS) && name == "section")
+        .unwrap()
+      {
+        sections.push(reader.expand_to_document().unwrap());
+      }
+      // reader dropped here — its copies of the subtrees are freed.
+    }
+
+    assert_eq!(sections.len(), 2, "should stream exactly two <section>s");
+
+    // Root of each owned doc is a <section> in the reconciled default ns.
+    let root0 = sections[0].get_root_element().unwrap();
+    assert_eq!(root0.get_name(), "section");
+    assert_eq!(root0.get_attribute("id").as_deref(), Some("a"));
+    assert_eq!(
+      root0.get_namespace().map(|n| n.get_href()),
+      Some(NS.to_string()),
+      "default namespace must be reconciled onto the detached copy"
+    );
+
+    // Serialization is intact and namespace-declared (no dangling ns → no UAF).
+    let s0 = sections[0].to_string();
+    assert!(s0.contains("http://example.org/ns"), "ns decl missing: {s0}");
+    assert!(s0.contains("Alpha") && s0.contains("one"), "content lost: {s0}");
+
+    // The second section keeps its prefixed namespace too.
+    let s1 = sections[1].to_string();
+    assert!(s1.contains("Beta"), "content lost: {s1}");
+    assert!(s1.contains("http://example.org/x"), "prefixed ns lost: {s1}");
+
+    std::fs::remove_file(&path).ok();
+  }
+
+  /// `read`/`next`/`is_element`/`local_name` walk the tree and `read_next` skips a
+  /// subtree (does not descend).
+  #[test]
+  fn read_and_next_skip_subtree() {
+    let xml = r#"<r><a><deep/></a><b/></r>"#;
+    let path = write_temp("skip", xml);
+    let mut reader = TextReader::from_file(&path, 0).unwrap();
+
+    assert!(reader.read().unwrap()); // <r>
+    assert!(reader.is_element());
+    assert_eq!(reader.local_name().as_deref(), Some("r"));
+
+    assert!(reader.read().unwrap()); // <a>
+    assert_eq!(reader.local_name().as_deref(), Some("a"));
+
+    // read_next() skips <a>'s subtree (the <deep/>) → lands on <b>.
+    assert!(reader.read_next().unwrap());
+    assert_eq!(reader.local_name().as_deref(), Some("b"));
+
+    std::fs::remove_file(&path).ok();
+  }
+}

--- a/src/readonly/tree.rs
+++ b/src/readonly/tree.rs
@@ -319,6 +319,12 @@ impl RoNode {
     let mut current_prop = xmlGetFirstProperty(self.0);
     while !current_prop.is_null() {
       let name_ptr = xmlAttrName(current_prop);
+      if name_ptr.is_null() {
+        // A property with a NULL name can't be keyed; skip it rather than
+        // `strlen(NULL)` inside `CStr::from_ptr`.
+        current_prop = xmlNextPropertySibling(current_prop);
+        continue;
+      }
       let c_name_string = unsafe { CStr::from_ptr(name_ptr) };
       let name = c_name_string.to_string_lossy().into_owned();
       let value = self.get_property(&name).unwrap_or_default();
@@ -336,6 +342,12 @@ impl RoNode {
     let mut current_prop = xmlGetFirstProperty(self.0);
     while !current_prop.is_null() {
       let name_ptr = xmlAttrName(current_prop);
+      if name_ptr.is_null() {
+        // A property with a NULL name can't be keyed; skip it rather than
+        // `strlen(NULL)` inside `CStr::from_ptr`.
+        current_prop = xmlNextPropertySibling(current_prop);
+        continue;
+      }
       let c_name_string = unsafe { CStr::from_ptr(name_ptr) };
       let name = c_name_string.to_string_lossy().into_owned();
       let ns_ptr = xmlAttrNs(current_prop);

--- a/src/readonly/tree.rs
+++ b/src/readonly/tree.rs
@@ -6,9 +6,9 @@ use std::str;
 
 use crate::bindings::*;
 use crate::c_helpers::*;
+use crate::tree::Document;
 use crate::tree::namespace::Namespace;
 use crate::tree::nodetype::NodeType;
-use crate::tree::Document;
 use crate::xpath::Context;
 
 /// Lightweight struct for read-only parallel processing

--- a/src/schemas/common.rs
+++ b/src/schemas/common.rs
@@ -20,7 +20,10 @@ pub unsafe extern "C" fn structured_error_handler(ctx: *mut c_void, error: bindi
 }
 
 #[cfg(not(libxml_older_than_2_12))]
-pub unsafe extern "C" fn structured_error_handler(ctx: *mut c_void, error: *const bindings::xmlError) {
+pub unsafe extern "C" fn structured_error_handler(
+  ctx: *mut c_void,
+  error: *const bindings::xmlError,
+) {
   assert!(!ctx.is_null());
   let errlog = unsafe { &mut *{ ctx as *mut Vec<StructuredError> } };
 

--- a/src/schemas/schema.rs
+++ b/src/schemas/schema.rs
@@ -17,7 +17,6 @@ pub struct Schema(*mut bindings::_xmlSchema);
 impl Schema {
   /// Create schema by having a SchemaParserContext do the actual parsing of the schema it was provided
   pub fn from_parser(parser: &mut SchemaParserContext) -> Result<Self, Vec<StructuredError>> {
-
     // `xmlSchemaParse` calls `xmlSchemaInitTypes`.
     // `xmlSchemaInitTypes` is a lazy function which is only intended to be
     // called once for optimization purposes - but libxml2 doesn't do this

--- a/src/schemas/validation.rs
+++ b/src/schemas/validation.rs
@@ -23,7 +23,6 @@ pub struct SchemaValidationContext {
   _schema: Schema,
 }
 
-
 impl SchemaValidationContext {
   /// Create a schema validation context from a parser object
   pub fn from_parser(parser: &mut SchemaParserContext) -> Result<Self, Vec<StructuredError>> {

--- a/src/tree/document.rs
+++ b/src/tree/document.rs
@@ -402,6 +402,15 @@ impl Document {
       let _size = xmlSaveClose(save_ctx);
 
       let result = xmlBufferContent(buf);
+      // `xmlBufferContent` returns NULL when the buffer never allocated its
+      // backing store — e.g. `xmlBufferCreate` returned NULL under memory
+      // pressure, a real event on a many-worker fleet. `CStr::from_ptr(NULL)`
+      // would then `strlen(NULL)` → SIGSEGV inside libc; degrade to an empty
+      // serialization instead (the buffer handle is still safe to free).
+      if result.is_null() {
+        xmlBufferFree(buf);
+        return String::new();
+      }
       let c_string = CStr::from_ptr(result as *const c_char);
       let node_string = c_string.to_string_lossy().into_owned();
       xmlBufferFree(buf);
@@ -425,6 +434,15 @@ impl Document {
         0, /* disable formatting */
       );
       let result = xmlBufferContent(buf);
+      // `xmlBufferContent` returns NULL when the buffer never allocated its
+      // backing store — e.g. `xmlBufferCreate` returned NULL under memory
+      // pressure, a real event on a many-worker fleet. `CStr::from_ptr(NULL)`
+      // would then `strlen(NULL)` → SIGSEGV inside libc; degrade to an empty
+      // serialization instead (the buffer handle is still safe to free).
+      if result.is_null() {
+        xmlBufferFree(buf);
+        return String::new();
+      }
       let c_string = CStr::from_ptr(result as *const c_char);
       let node_string = c_string.to_string_lossy().into_owned();
       xmlBufferFree(buf);
@@ -447,6 +465,15 @@ impl Document {
         0, /* disable formatting */
       );
       let result = xmlBufferContent(buf);
+      // `xmlBufferContent` returns NULL when the buffer never allocated its
+      // backing store — e.g. `xmlBufferCreate` returned NULL under memory
+      // pressure, a real event on a many-worker fleet. `CStr::from_ptr(NULL)`
+      // would then `strlen(NULL)` → SIGSEGV inside libc; degrade to an empty
+      // serialization instead (the buffer handle is still safe to free).
+      if result.is_null() {
+        xmlBufferFree(buf);
+        return String::new();
+      }
       let c_string = CStr::from_ptr(result as *const c_char);
       let node_string = c_string.to_string_lossy().into_owned();
       xmlBufferFree(buf);

--- a/src/tree/document/c14n.rs
+++ b/src/tree/document/c14n.rs
@@ -82,7 +82,7 @@ unsafe fn create_output_buffer() -> xmlOutputBufferPtr {
     // `xmlC14NExecute` treats a NULL buffer as an error (< 0), so the caller
     // surfaces `Err(())`.
     if buf.is_null() {
-      drop(Box::from_raw(ctx_ptr as *mut String));
+      drop(Box::from_raw(ctx_ptr));
       return buf;
     }
 

--- a/src/tree/document/c14n.rs
+++ b/src/tree/document/c14n.rs
@@ -1,14 +1,14 @@
 //! Document canonicalization logic
 //!
-use std::ffi::{c_int, c_void, CString};
+use std::ffi::{CString, c_int, c_void};
 use std::os::raw;
 use std::ptr::null_mut;
 
 use crate::tree::c14n::*;
 
 use super::{
-  xmlAllocOutputBuffer, xmlC14NExecute, xmlC14NIsVisibleCallback, xmlChar, xmlNodePtr,
-  xmlOutputBufferClose, xmlOutputBufferPtr, Document,
+  Document, xmlAllocOutputBuffer, xmlC14NExecute, xmlC14NIsVisibleCallback, xmlChar, xmlNodePtr,
+  xmlOutputBufferClose, xmlOutputBufferPtr,
 };
 
 impl Document {
@@ -46,39 +46,53 @@ impl Document {
 
       let res = c_obuf_into_output(c_obuf);
 
-      if status < 0 {
-        Err(())
-      } else {
-        Ok(res)
-      }
+      if status < 0 { Err(()) } else { Ok(res) }
     }
   }
 }
 
-unsafe fn c_obuf_into_output(c_obuf: xmlOutputBufferPtr) -> String { unsafe {
-  let ctx_ptr = (*c_obuf).context;
-  let output = Box::from_raw(ctx_ptr as *mut String);
+unsafe fn c_obuf_into_output(c_obuf: xmlOutputBufferPtr) -> String {
+  unsafe {
+    // A NULL buffer (allocation failed in `create_output_buffer`) has no
+    // captured context to recover — yield an empty canonicalization rather
+    // than dereferencing address 0.
+    if c_obuf.is_null() {
+      return String::new();
+    }
+    let ctx_ptr = (*c_obuf).context;
+    let output = Box::from_raw(ctx_ptr as *mut String);
 
-  (*c_obuf).context = std::ptr::null_mut::<c_void>();
+    (*c_obuf).context = std::ptr::null_mut::<c_void>();
 
-  xmlOutputBufferClose(c_obuf);
+    xmlOutputBufferClose(c_obuf);
 
-  *output
-}}
+    *output
+  }
+}
 
-unsafe fn create_output_buffer() -> xmlOutputBufferPtr { unsafe {
-  let output = String::new();
-  let ctx_ptr = Box::into_raw(Box::new(output));
-  let encoder = std::ptr::null_mut();
+unsafe fn create_output_buffer() -> xmlOutputBufferPtr {
+  unsafe {
+    let output = String::new();
+    let ctx_ptr = Box::into_raw(Box::new(output));
+    let encoder = std::ptr::null_mut();
 
-  let buf = xmlAllocOutputBuffer(encoder);
+    let buf = xmlAllocOutputBuffer(encoder);
+    // libxml2 returns NULL on allocation failure; reclaim the context box we
+    // just leaked and propagate NULL rather than dereferencing address 0.
+    // `xmlC14NExecute` treats a NULL buffer as an error (< 0), so the caller
+    // surfaces `Err(())`.
+    if buf.is_null() {
+      drop(Box::from_raw(ctx_ptr as *mut String));
+      return buf;
+    }
 
-  (*buf).writecallback = Some(xml_write_io);
-  (*buf).closecallback = Some(xml_close_io);
-  (*buf).context = ctx_ptr as _;
+    (*buf).writecallback = Some(xml_write_io);
+    (*buf).closecallback = Some(xml_close_io);
+    (*buf).context = ctx_ptr as _;
 
-  buf
-}}
+    buf
+  }
+}
 
 unsafe extern "C" fn xml_close_io(_context: *mut raw::c_void) -> raw::c_int {
   0
@@ -88,18 +102,20 @@ unsafe extern "C" fn xml_write_io(
   io_ptr: *mut raw::c_void,
   buffer: *const raw::c_char,
   len: raw::c_int,
-) -> raw::c_int { unsafe {
-  if io_ptr.is_null() {
-    0
-  } else {
-    let buf = std::slice::from_raw_parts_mut(buffer as *mut u8, len as usize);
-    let buf = String::from_utf8_lossy(buf);
-    let s2_ptr = io_ptr as *mut String;
-    String::push_str(&mut *s2_ptr, &buf);
+) -> raw::c_int {
+  unsafe {
+    if io_ptr.is_null() {
+      0
+    } else {
+      let buf = std::slice::from_raw_parts_mut(buffer as *mut u8, len as usize);
+      let buf = String::from_utf8_lossy(buf);
+      let s2_ptr = io_ptr as *mut String;
+      String::push_str(&mut *s2_ptr, &buf);
 
-    len
+      len
+    }
   }
-}}
+}
 
 /// Create a [Vec] of null-terminated [*mut xmlChar] strings
 fn to_xml_string_vec(vec: Vec<String>) -> Vec<*mut xmlChar> {

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -845,6 +845,12 @@ impl Node {
     let mut current_prop = xmlGetFirstProperty(self.node_ptr());
     while !current_prop.is_null() {
       let name_ptr = xmlAttrName(current_prop);
+      if name_ptr.is_null() {
+        // A property with a NULL name can't be keyed; skip it rather than
+        // `strlen(NULL)` inside `CStr::from_ptr`.
+        current_prop = xmlNextPropertySibling(current_prop);
+        continue;
+      }
       let c_name_string = unsafe { CStr::from_ptr(name_ptr) };
       let name = c_name_string.to_string_lossy().into_owned();
       // Read the value straight from the attribute node we already hold, rather
@@ -867,6 +873,12 @@ impl Node {
     let mut current_prop = xmlGetFirstProperty(self.node_ptr());
     while !current_prop.is_null() {
       let name_ptr = xmlAttrName(current_prop);
+      if name_ptr.is_null() {
+        // A property with a NULL name can't be keyed; skip it rather than
+        // `strlen(NULL)` inside `CStr::from_ptr`.
+        current_prop = xmlNextPropertySibling(current_prop);
+        continue;
+      }
       let c_name_string = unsafe { CStr::from_ptr(name_ptr) };
       let name = c_name_string.to_string_lossy().into_owned();
       // Same direct-read optimization as `get_properties`: the value is read

--- a/src/tree/node/c14n.rs
+++ b/src/tree/node/c14n.rs
@@ -5,7 +5,7 @@ use std::ffi::c_void;
 use crate::{
   bindings::{xmlC14NIsVisibleCallback, xmlElementType, xmlNodePtr},
   c_helpers::xmlGetNodeType,
-  tree::{c14n::*, Node},
+  tree::{Node, c14n::*},
 };
 
 use super::node_ancestors;
@@ -40,11 +40,7 @@ unsafe extern "C" fn callback_wrapper(
   let tn_ancestors = node_ancestors(tn_ptr);
 
   let ret = (tn_ptr == c14n_root_ptr) || tn_ancestors.contains(&c14n_root_ptr);
-  if ret {
-    1
-  } else {
-    0
-  }
+  if ret { 1 } else { 0 }
 }
 
 const C14_NODE_TYPES: [xmlElementType; 7] = [

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -2,6 +2,7 @@
 
 use crate::bindings::*;
 use crate::c_helpers::*;
+use crate::error::StructuredError;
 use crate::readonly::RoNode;
 use crate::tree::{Document, DocumentRef, DocumentWeak, Node};
 use libc::{c_char, c_void, size_t};
@@ -42,6 +43,78 @@ pub struct Object {
   pub ptr: xmlXPathObjectPtr,
   document: DocumentWeak,
 }
+
+/// A structured error raised while evaluating an XPath expression.
+///
+/// libxml2 aborts an evaluation (returning a NULL result object) for several
+/// reasons — most notably when a `//X[predicate]` query has to materialize
+/// more than `XPATH_MAX_NODESET_LENGTH` (10,000,000) intermediate nodes and
+/// hits the internal *"growing nodeset hit limit"*. The thinly-wrapped
+/// [`Context::evaluate`] / [`Context::node_evaluate`] collapse every such
+/// failure into a bare `Err(())`, which hides the cause from callers. The
+/// `*_checked` variants instead snapshot libxml2's last recorded error into
+/// this struct so the real message can be logged or propagated.
+#[derive(Debug, Clone)]
+pub struct XPathError {
+  /// Human-readable message from libxml2 (e.g. `"growing nodeset hit limit"`),
+  /// if one was recorded.
+  pub message: Option<String>,
+  /// libxml2 error code (`xmlParserErrors` enum). `0` when unknown.
+  pub code: i32,
+  /// libxml2 error domain (`xmlErrorDomain` enum). `0` when unknown.
+  pub domain: i32,
+}
+
+impl XPathError {
+  /// Snapshot the current thread's last libxml2 error — set by libxml2 when an
+  /// evaluation returns NULL. Falls back to an empty message when libxml2 did
+  /// not record structured detail.
+  fn from_last_error() -> Self {
+    let err_ptr = unsafe { xmlGetLastError() };
+    if err_ptr.is_null() {
+      XPathError {
+        message: None,
+        code: 0,
+        domain: 0,
+      }
+    } else {
+      let se = unsafe { StructuredError::from_raw(err_ptr) };
+      XPathError {
+        message: se.message,
+        code: se.code,
+        domain: se.domain,
+      }
+    }
+  }
+
+  /// True when this is libxml2's XPath nodeset-length ceiling — the signal that
+  /// a `//`-materializing query grew past the 10M-node internal limit (rather
+  /// than a syntax error or a missing namespace). The message text is the
+  /// reliable discriminator; the underlying code is a generic memory error.
+  pub fn is_nodeset_limit(&self) -> bool {
+    self
+      .message
+      .as_deref()
+      .is_some_and(|m| m.contains("nodeset") || m.contains("Memory allocation failed"))
+  }
+}
+
+impl fmt::Display for XPathError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match &self.message {
+      Some(m) => write!(
+        f,
+        "XPath evaluation error: {} (code {}, domain {})",
+        m.trim(),
+        self.code,
+        self.domain
+      ),
+      None => write!(f, "XPath evaluation failed (no libxml2 error detail)"),
+    }
+  }
+}
+
+impl std::error::Error for XPathError {}
 
 impl Context {
   ///create the xpath context for a document
@@ -96,10 +169,22 @@ impl Context {
 
   ///evaluate an xpath
   pub fn evaluate(&self, xpath: &str) -> Result<Object, ()> {
+    self.evaluate_checked(xpath).map_err(|_| ())
+  }
+
+  /// Evaluate an XPath expression, returning libxml2's structured error on
+  /// failure instead of a bare `()`. This surfaces causes that the thin
+  /// [`Context::evaluate`] hides — most importantly the *"growing nodeset hit
+  /// limit"* raised when a `//X[predicate]` query materializes more than
+  /// `XPATH_MAX_NODESET_LENGTH` intermediate nodes on a very large document.
+  pub fn evaluate_checked(&self, xpath: &str) -> Result<Object, XPathError> {
     let c_xpath = CString::new(xpath).unwrap();
+    // Reset first so `from_last_error` reads THIS evaluation's error, not a
+    // stale one left by an earlier operation on this thread.
+    unsafe { xmlResetLastError() };
     let ptr = unsafe { xmlXPathEvalExpression(c_xpath.as_bytes().as_ptr(), self.as_ptr()) };
     if ptr.is_null() {
-      Err(())
+      Err(XPathError::from_last_error())
     } else {
       Ok(Object {
         ptr,
@@ -110,11 +195,18 @@ impl Context {
 
   ///evaluate an xpath on a context Node
   pub fn node_evaluate(&self, xpath: &str, node: &Node) -> Result<Object, ()> {
+    self.node_evaluate_checked(xpath, node).map_err(|_| ())
+  }
+
+  /// Evaluate an XPath expression relative to `node`, returning libxml2's
+  /// structured error on failure. See [`Context::evaluate_checked`].
+  pub fn node_evaluate_checked(&self, xpath: &str, node: &Node) -> Result<Object, XPathError> {
     let c_xpath = CString::new(xpath).unwrap();
+    unsafe { xmlResetLastError() };
     let ptr =
       unsafe { xmlXPathNodeEval(node.node_ptr(), c_xpath.as_bytes().as_ptr(), self.as_ptr()) };
     if ptr.is_null() {
-      Err(())
+      Err(XPathError::from_last_error())
     } else {
       Ok(Object {
         ptr,
@@ -125,10 +217,21 @@ impl Context {
 
   ///evaluate an xpath on a context RoNode
   pub fn node_evaluate_readonly(&self, xpath: &str, node: RoNode) -> Result<Object, ()> {
+    self.node_evaluate_readonly_checked(xpath, node).map_err(|_| ())
+  }
+
+  /// Evaluate an XPath expression relative to a read-only `node`, returning
+  /// libxml2's structured error on failure. See [`Context::evaluate_checked`].
+  pub fn node_evaluate_readonly_checked(
+    &self,
+    xpath: &str,
+    node: RoNode,
+  ) -> Result<Object, XPathError> {
     let c_xpath = CString::new(xpath).unwrap();
+    unsafe { xmlResetLastError() };
     let ptr = unsafe { xmlXPathNodeEval(node.0, c_xpath.as_bytes().as_ptr(), self.as_ptr()) };
     if ptr.is_null() {
-      Err(())
+      Err(XPathError::from_last_error())
     } else {
       Ok(Object {
         ptr,

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -44,31 +44,27 @@ pub struct Object {
   document: DocumentWeak,
 }
 
-/// A structured error raised while evaluating an XPath expression.
+/// A structured error from an XPath evaluation.
 ///
-/// libxml2 aborts an evaluation (returning a NULL result object) for several
-/// reasons — most notably when a `//X[predicate]` query has to materialize
-/// more than `XPATH_MAX_NODESET_LENGTH` (10,000,000) intermediate nodes and
-/// hits the internal *"growing nodeset hit limit"*. The thinly-wrapped
-/// [`Context::evaluate`] / [`Context::node_evaluate`] collapse every such
-/// failure into a bare `Err(())`, which hides the cause from callers. The
-/// `*_checked` variants instead snapshot libxml2's last recorded error into
-/// this struct so the real message can be logged or propagated.
+/// libxml2 returns a NULL result — which the bare [`Context::evaluate`] family
+/// collapses to `Err(())` — for several reasons, most importantly the
+/// *"growing nodeset hit limit"* when a `//X[predicate]` query materializes
+/// more than `XPATH_MAX_NODESET_LENGTH` (10M) nodes on a huge document. The
+/// `*_checked` variants snapshot libxml2's last error here so the cause is
+/// recoverable; see [`is_nodeset_limit`](Self::is_nodeset_limit).
 #[derive(Debug, Clone)]
 pub struct XPathError {
-  /// Human-readable message from libxml2 (e.g. `"growing nodeset hit limit"`),
-  /// if one was recorded.
+  /// libxml2's message (e.g. `"growing nodeset hit limit"`), if recorded.
   pub message: Option<String>,
-  /// libxml2 error code (`xmlParserErrors` enum). `0` when unknown.
+  /// libxml2 error code (`xmlParserErrors`). `0` when unknown.
   pub code: i32,
-  /// libxml2 error domain (`xmlErrorDomain` enum). `0` when unknown.
+  /// libxml2 error domain (`xmlErrorDomain`). `0` when unknown.
   pub domain: i32,
 }
 
 impl XPathError {
-  /// Snapshot the current thread's last libxml2 error — set by libxml2 when an
-  /// evaluation returns NULL. Falls back to an empty message when libxml2 did
-  /// not record structured detail.
+  /// Snapshot the thread's last libxml2 error (set when an evaluation returns
+  /// NULL); empty message when libxml2 recorded no structured detail.
   fn from_last_error() -> Self {
     let err_ptr = unsafe { xmlGetLastError() };
     if err_ptr.is_null() {
@@ -167,22 +163,18 @@ impl Context {
     }
   }
 
-  ///evaluate an xpath
-  pub fn evaluate(&self, xpath: &str) -> Result<Object, ()> {
-    self.evaluate_checked(xpath).map_err(|_| ())
-  }
-
-  /// Evaluate an XPath expression, returning libxml2's structured error on
-  /// failure instead of a bare `()`. This surfaces causes that the thin
-  /// [`Context::evaluate`] hides — most importantly the *"growing nodeset hit
-  /// limit"* raised when a `//X[predicate]` query materializes more than
-  /// `XPATH_MAX_NODESET_LENGTH` intermediate nodes on a very large document.
-  pub fn evaluate_checked(&self, xpath: &str) -> Result<Object, XPathError> {
+  /// Shared body of the `*_checked` evaluators: reset the thread's last error
+  /// (so [`XPathError::from_last_error`] reads THIS call's failure, not a stale
+  /// one), run `eval`, and wrap the raw object — surfacing the structured error
+  /// when libxml2 returns NULL. `eval` receives the NUL-terminated expression.
+  fn eval_checked(
+    &self,
+    xpath: &str,
+    eval: impl FnOnce(*const u8) -> xmlXPathObjectPtr,
+  ) -> Result<Object, XPathError> {
     let c_xpath = CString::new(xpath).unwrap();
-    // Reset first so `from_last_error` reads THIS evaluation's error, not a
-    // stale one left by an earlier operation on this thread.
     unsafe { xmlResetLastError() };
-    let ptr = unsafe { xmlXPathEvalExpression(c_xpath.as_bytes().as_ptr(), self.as_ptr()) };
+    let ptr = eval(c_xpath.as_bytes().as_ptr());
     if ptr.is_null() {
       Err(XPathError::from_last_error())
     } else {
@@ -191,6 +183,19 @@ impl Context {
         document: self.document.clone(),
       })
     }
+  }
+
+  ///evaluate an xpath
+  pub fn evaluate(&self, xpath: &str) -> Result<Object, ()> {
+    self.evaluate_checked(xpath).map_err(|_| ())
+  }
+
+  /// Evaluate `xpath`, returning libxml2's structured [`XPathError`] on failure
+  /// instead of the bare `()` that [`Context::evaluate`] yields.
+  pub fn evaluate_checked(&self, xpath: &str) -> Result<Object, XPathError> {
+    self.eval_checked(xpath, |s| unsafe {
+      xmlXPathEvalExpression(s, self.as_ptr())
+    })
   }
 
   ///evaluate an xpath on a context Node
@@ -198,46 +203,30 @@ impl Context {
     self.node_evaluate_checked(xpath, node).map_err(|_| ())
   }
 
-  /// Evaluate an XPath expression relative to `node`, returning libxml2's
-  /// structured error on failure. See [`Context::evaluate_checked`].
+  /// Evaluate `xpath` relative to `node`. See [`Context::evaluate_checked`].
   pub fn node_evaluate_checked(&self, xpath: &str, node: &Node) -> Result<Object, XPathError> {
-    let c_xpath = CString::new(xpath).unwrap();
-    unsafe { xmlResetLastError() };
-    let ptr =
-      unsafe { xmlXPathNodeEval(node.node_ptr(), c_xpath.as_bytes().as_ptr(), self.as_ptr()) };
-    if ptr.is_null() {
-      Err(XPathError::from_last_error())
-    } else {
-      Ok(Object {
-        ptr,
-        document: self.document.clone(),
-      })
-    }
+    self.eval_checked(xpath, |s| unsafe {
+      xmlXPathNodeEval(node.node_ptr(), s, self.as_ptr())
+    })
   }
 
   ///evaluate an xpath on a context RoNode
   pub fn node_evaluate_readonly(&self, xpath: &str, node: RoNode) -> Result<Object, ()> {
-    self.node_evaluate_readonly_checked(xpath, node).map_err(|_| ())
+    self
+      .node_evaluate_readonly_checked(xpath, node)
+      .map_err(|_| ())
   }
 
-  /// Evaluate an XPath expression relative to a read-only `node`, returning
-  /// libxml2's structured error on failure. See [`Context::evaluate_checked`].
+  /// Evaluate `xpath` relative to a read-only `node`. See
+  /// [`Context::evaluate_checked`].
   pub fn node_evaluate_readonly_checked(
     &self,
     xpath: &str,
     node: RoNode,
   ) -> Result<Object, XPathError> {
-    let c_xpath = CString::new(xpath).unwrap();
-    unsafe { xmlResetLastError() };
-    let ptr = unsafe { xmlXPathNodeEval(node.0, c_xpath.as_bytes().as_ptr(), self.as_ptr()) };
-    if ptr.is_null() {
-      Err(XPathError::from_last_error())
-    } else {
-      Ok(Object {
-        ptr,
-        document: self.document.clone(),
-      })
-    }
+    self.eval_checked(xpath, |s| unsafe {
+      xmlXPathNodeEval(node.0, s, self.as_ptr())
+    })
   }
 
   /// localize xpath context to a specific Node

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -90,11 +90,7 @@ impl Context {
         c_prefix.as_bytes().as_ptr(),
         c_href.as_bytes().as_ptr(),
       );
-      if result != 0 {
-        Err(())
-      } else {
-        Ok(())
-      }
+      if result != 0 { Err(()) } else { Ok(()) }
     }
   }
 
@@ -267,7 +263,6 @@ impl Object {
     }
     vec
   }
-
 }
 
 impl fmt::Display for Object {

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -256,6 +256,11 @@ impl Object {
         panic!("rust-libxml: xpath: found null pointer result set");
       }
       let value_ptr = unsafe { xmlXPathCastNodeToString(ptr) };
+      if value_ptr.is_null() {
+        // OOM in the cast; record an empty string rather than `strlen(NULL)`.
+        vec.push(String::new());
+        continue;
+      }
       let c_value_string = unsafe { CStr::from_ptr(value_ptr as *const c_char) };
       let ready_str = c_value_string.to_string_lossy().into_owned();
       bindgenFree(value_ptr as *mut c_void);
@@ -270,6 +275,10 @@ impl fmt::Display for Object {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     unsafe {
       let receiver = xmlXPathCastToString(self.ptr);
+      if receiver.is_null() {
+        // OOM in the cast; write nothing rather than `strlen(NULL)`.
+        return Ok(());
+      }
       let c_string = CStr::from_ptr(receiver as *const c_char);
       let rust_string = str::from_utf8(c_string.to_bytes()).unwrap().to_owned();
       bindgenFree(receiver as *mut c_void);

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -122,11 +122,13 @@ fn document_can_import_node() {
   let mut node = elements.pop().unwrap();
   node.unlink();
   let mut imported = doc2.import_node(&mut node).unwrap();
-  assert!(doc2
-    .get_root_element()
-    .unwrap()
-    .add_child(&mut imported)
-    .is_ok());
+  assert!(
+    doc2
+      .get_root_element()
+      .unwrap()
+      .add_child(&mut imported)
+      .is_ok()
+  );
 
   assert_eq!(
     doc2.get_root_element().unwrap().get_child_elements().len(),
@@ -212,9 +214,7 @@ fn serialization_roundtrip(file_name: &str) {
 }
 
 fn strip_whitespace(string: &str) -> String {
-  string.replace("\r","")
-    .replace("\n", "")
-    .replace(" ", "")
+  string.replace("\r", "").replace("\n", "").replace(" ", "")
 }
 
 #[test]

--- a/tests/c14n.rs
+++ b/tests/c14n.rs
@@ -2,13 +2,13 @@ use libxml::parser::Parser;
 use libxml::tree::c14n::{CanonicalizationMode, CanonicalizationOptions};
 
 fn assert_eq_lines(seen: &str, expected: &str) {
-    let lines_iter = seen.lines().zip(expected.lines());
+  let lines_iter = seen.lines().zip(expected.lines());
 
-    for (seen_line, expected_line) in lines_iter {
-      assert_eq!(seen_line, expected_line);
-    }
+  for (seen_line, expected_line) in lines_iter {
+    assert_eq!(seen_line, expected_line);
+  }
 
-    assert_eq!(seen.lines().count(), expected.lines().count());
+  assert_eq!(seen.lines().count(), expected.lines().count());
 }
 
 fn canonicalize_xml(input: &str, opts: CanonicalizationOptions) -> String {

--- a/tests/dup_node_into_new_doc_tests.rs
+++ b/tests/dup_node_into_new_doc_tests.rs
@@ -11,9 +11,7 @@ use libxml::tree::{Document, Node};
 fn dup_node_into_new_doc_basic() {
   let parser = Parser::default();
   let src = parser
-    .parse_string(
-      "<root xmlns=\"http://example.com/ns\"><a id=\"x\"><b/></a><c/></root>",
-    )
+    .parse_string("<root xmlns=\"http://example.com/ns\"><a id=\"x\"><b/></a><c/></root>")
     .expect("parse src");
   let root = src.get_root_element().expect("src root");
   // pick the <a> child
@@ -257,8 +255,8 @@ fn dup_node_into_new_doc_many_ns_repeated() {
 
   let mut subdocs = Vec::new();
   for (i, p) in pages.iter().enumerate() {
-    let sub = Document::dup_node_into_new_doc(p)
-      .unwrap_or_else(|_| panic!("ns-stress dup #{i} failed"));
+    let sub =
+      Document::dup_node_into_new_doc(p).unwrap_or_else(|_| panic!("ns-stress dup #{i} failed"));
     subdocs.push(sub);
   }
   assert_eq!(subdocs.len(), 5);
@@ -295,7 +293,10 @@ fn dup_node_into_new_doc_large_doc_siblings() {
         .unwrap_or(false)
     })
     .collect();
-  assert!(pages.len() >= 2, "need at least 2 section siblings to repro");
+  assert!(
+    pages.len() >= 2,
+    "need at least 2 section siblings to repro"
+  );
   // Detach each page from its parent before duping (mirrors a
   // document-splitter that pops siblings from the parent first).
   for p in pages.iter_mut() {
@@ -325,9 +326,7 @@ fn dup_node_into_new_doc_large_doc_siblings() {
 fn dup_node_into_new_doc_xpath_then_dup_at_scale() {
   // Build a doc with 5 sibling sections, each carrying ~200 xml:id'd
   // descendants. Total: ~1000 ids on the source.
-  let mut xml = String::from(
-    "<root xmlns=\"http://example.com/ns\">",
-  );
+  let mut xml = String::from("<root xmlns=\"http://example.com/ns\">");
   for i in 0..5 {
     xml.push_str(&format!("<s xml:id=\"s{i}\">"));
     for j in 0..200 {
@@ -362,7 +361,11 @@ fn dup_node_into_new_doc_xpath_then_dup_at_scale() {
     let hits = p
       .findnodes("descendant-or-self::*[@*[local-name()='id']]")
       .unwrap_or_default();
-    assert!(hits.len() > 100, "expected many xml:id hits, got {}", hits.len());
+    assert!(
+      hits.len() > 100,
+      "expected many xml:id hits, got {}",
+      hits.len()
+    );
     let sub = Document::dup_node_into_new_doc(p)
       .unwrap_or_else(|_| panic!("dup #{i} returned NULL after XPath descent"));
     subdocs.push(sub);

--- a/tests/mutability_guards.rs
+++ b/tests/mutability_guards.rs
@@ -21,15 +21,27 @@ fn clones_do_not_block_mutation() {
   let mut first_a = root.get_first_element_child().unwrap();
   let first_b = root.get_first_element_child().unwrap();
 
-  assert_eq!(first_a.get_attribute("attribute"), Some(String::from("value")));
-  assert_eq!(first_b.get_attribute("attribute"), Some(String::from("value")));
+  assert_eq!(
+    first_a.get_attribute("attribute"),
+    Some(String::from("value"))
+  );
+  assert_eq!(
+    first_b.get_attribute("attribute"),
+    Some(String::from("value"))
+  );
 
   // Previously this returned Err purely from the clone count; it must now succeed.
   assert!(first_a.set_attribute("attribute", "newa").is_ok());
 
   // Both handles alias the same underlying C node, so both observe the change.
-  assert_eq!(first_a.get_attribute("attribute"), Some(String::from("newa")));
-  assert_eq!(first_b.get_attribute("attribute"), Some(String::from("newa")));
+  assert_eq!(
+    first_a.get_attribute("attribute"),
+    Some(String::from("newa"))
+  );
+  assert_eq!(
+    first_b.get_attribute("attribute"),
+    Some(String::from("newa"))
+  );
 }
 
 /// The former tuning knob `set_node_rc_guard` is now a deprecated no-op, retained

--- a/tests/null_safety.rs
+++ b/tests/null_safety.rs
@@ -1,0 +1,42 @@
+//! Regression tests for NULL-node FFI safety.
+//!
+//! A `Node::null()` placeholder wraps a NULL `xmlNodePtr`. Every field accessor
+//! must degrade to the natural "absence" value instead of dereferencing address
+//! 0 — e.g. `get_type()` reads the node's `type_` at **offset 8**, so a raw
+//! deref on NULL is the `segfault at 8` observed in production. A crash here
+//! bypasses `catch_unwind` and takes down the whole process. These tests pin
+//! the null guards in `src/c_helpers.rs`; before them, every assertion below
+//! was a SIGSEGV rather than a value.
+
+use libxml::tree::Node;
+
+#[test]
+fn null_node_get_type_is_none() {
+  // The exact production fault: `xmlGetNodeType(NULL)` reading offset 8.
+  assert_eq!(Node::null().get_type(), None);
+}
+
+#[test]
+fn null_node_is_not_element() {
+  assert!(!Node::null().is_element_node());
+}
+
+#[test]
+fn null_node_navigation_is_none() {
+  let n = Node::null();
+  assert!(n.get_parent().is_none());
+  assert!(n.get_first_child().is_none());
+  assert!(n.get_last_child().is_none());
+  assert!(n.get_next_sibling().is_none());
+  assert!(n.get_prev_sibling().is_none());
+  assert!(n.get_first_element_child().is_none());
+  assert!(n.get_next_element_sibling().is_none());
+  assert!(n.get_prev_element_sibling().is_none());
+}
+
+#[test]
+fn null_node_name_and_content_are_empty() {
+  let n = Node::null();
+  assert_eq!(n.get_name(), String::new());
+  assert_eq!(n.get_content(), String::new());
+}

--- a/tests/rust_owned_tests.rs
+++ b/tests/rust_owned_tests.rs
@@ -173,10 +173,7 @@ fn rust_owned_split_extract_stress() {
   for (i, sub) in subdocs.iter().enumerate() {
     let sub_root = sub.get_root_element().expect("sub root");
     assert_eq!(sub_root.get_name(), "section");
-    assert_eq!(
-      sub_root.get_attribute("id"),
-      Some(format!("s{}", i))
-    );
+    assert_eq!(sub_root.get_attribute("id"), Some(format!("s{}", i)));
   }
 
   drop(subdocs);

--- a/tests/schema_tests.rs
+++ b/tests/schema_tests.rs
@@ -77,7 +77,6 @@ static INVALID_STOCK_XML: &str = r#"<?xml version="1.0"?>
 </stock
 "#;
 
-
 // TODO: This test has revealed SchemaParserContext+SchemaValidationContext are not safe for
 //       multi-threaded use in libxml >=2.12, at least not as currently implemented.
 //       while it still reliably succeeds single-threaded, new implementation is needed to use
@@ -146,7 +145,7 @@ fn schema_from_string_reports_unique_errors() {
   let xml = Parser::default()
     .parse_string(INVALID_STOCK_XML)
     .expect("Expected to be able to parse XML Document from string");
-  
+
   let mut xsdparser = SchemaParserContext::from_buffer(STOCK_SCHEMA);
   let xsd = SchemaValidationContext::from_parser(&mut xsdparser);
 
@@ -167,10 +166,16 @@ fn schema_from_string_reports_unique_errors() {
         "Element 'stock': The attribute 'ticker' is required but missing.\n",
         "Element 'stock': The attribute 'exchange' is required but missing.\n",
         "Element 'price': 'NOT A NUMBER' is not a valid value of the atomic type 'xs:float'.\n",
-        "Element 'date': 'NOT A DATE' is not a valid value of the atomic type 'xs:date'.\n"
+        "Element 'date': 'NOT A DATE' is not a valid value of the atomic type 'xs:date'.\n",
       ];
       for err_msg in expected_errors {
-        assert!(errors.iter().any(|err| err.message.as_ref().unwrap() == err_msg), "Expected error message {} was not found", err_msg);
+        assert!(
+          errors
+            .iter()
+            .any(|err| err.message.as_ref().unwrap() == err_msg),
+          "Expected error message {} was not found",
+          err_msg
+        );
       }
     }
   }

--- a/tests/tree_tests.rs
+++ b/tests/tree_tests.rs
@@ -15,17 +15,23 @@ fn child_of_root_has_different_hash() {
     let doc = doc_result.unwrap();
     let root = doc.get_root_element().unwrap();
     assert!(!root.is_text_node());
-    match root.get_first_child() { Some(child) => {
-      assert!(root != child);
-    } _ => {
-      unreachable!("test failed - first child doesn't exist");
-    }}
+    match root.get_first_child() {
+      Some(child) => {
+        assert!(root != child);
+      }
+      _ => {
+        unreachable!("test failed - first child doesn't exist");
+      }
+    }
     // same check with last child
-    match root.get_last_child() { Some(child) => {
-      assert!(root != child);
-    } _ => {
-      unreachable!("test failed - last child doesn't exist");
-    }}
+    match root.get_last_child() {
+      Some(child) => {
+        assert!(root != child);
+      }
+      _ => {
+        unreachable!("test failed - last child doesn't exist");
+      }
+    }
   }
 }
 
@@ -254,9 +260,11 @@ fn node_attributes_ns_accessor() {
     child.get_attribute_no_ns("attribute"),
     Some("setter_value".to_string())
   );
-  assert!(child
-    .set_attribute_ns("attribute", "foo_value", &foo_ns)
-    .is_ok());
+  assert!(
+    child
+      .set_attribute_ns("attribute", "foo_value", &foo_ns)
+      .is_ok()
+  );
   assert_eq!(
     child.get_attribute_no_ns("attribute"),
     Some("setter_value".to_string())
@@ -350,9 +358,11 @@ fn attribute_namespace_accessors() {
     element.get_attribute_ns("fb", "http://www.foobar.org"),
     Some("fb".to_string())
   );
-  assert!(element
-    .remove_attribute_ns("fb", "http://www.foobar.org")
-    .is_ok());
+  assert!(
+    element
+      .remove_attribute_ns("fb", "http://www.foobar.org")
+      .is_ok()
+  );
   assert_eq!(
     element.get_attribute_ns("fb", "http://www.foobar.org"),
     None
@@ -642,9 +652,11 @@ fn can_replace_child() {
 
   // fail to replace a, as it is already removed.
   let none = Node::new("none", None, &doc).unwrap();
-  assert!(root_node
-    .replace_child_node(none, a_result.unwrap())
-    .is_err());
+  assert!(
+    root_node
+      .replace_child_node(none, a_result.unwrap())
+      .is_err()
+  );
   // no change.
   assert_eq!(
     doc.to_string(),

--- a/tests/xml_copy_invariant_tests.rs
+++ b/tests/xml_copy_invariant_tests.rs
@@ -5,7 +5,6 @@
 use libxml::parser::Parser;
 use libxml::tree::{Document, Node};
 
-
 #[test]
 /// Source-doc corruption test: after a single xmlCopyDoc + xmlFreeDoc
 /// of the copy, can we still read xml:id attributes off the source?
@@ -44,7 +43,10 @@ fn xml_copy_doc_does_not_corrupt_source() {
   // After the copy round-trip, source xml:ids must still be readable.
   let post: Vec<Option<String>> = sections.iter().map(|s| s.get_attribute("xml:id")).collect();
   for (i, (p, q)) in pre.iter().zip(post.iter()).enumerate() {
-    assert_eq!(p, q, "section {i} xml:id changed across xmlCopyDoc round-trip: {p:?} -> {q:?}");
+    assert_eq!(
+      p, q,
+      "section {i} xml:id changed across xmlCopyDoc round-trip: {p:?} -> {q:?}"
+    );
   }
 }
 
@@ -90,7 +92,10 @@ fn xml_copy_doc_does_not_corrupt_source_after_init_walks() {
 
   let post: Vec<Option<String>> = sections.iter().map(|s| s.get_attribute("xml:id")).collect();
   for (i, (p, q)) in pre.iter().zip(post.iter()).enumerate() {
-    assert_eq!(p, q, "section {i} xml:id changed across copy/free: {p:?} -> {q:?}");
+    assert_eq!(
+      p, q,
+      "section {i} xml:id changed across copy/free: {p:?} -> {q:?}"
+    );
   }
 }
 
@@ -145,7 +150,10 @@ fn xml_copy_doc_no_corrupt_after_unlink() {
 
   let post: Vec<Option<String>> = sections.iter().map(|s| s.get_attribute("xml:id")).collect();
   for (i, (p, q)) in pre.iter().zip(post.iter()).enumerate() {
-    assert_eq!(p, q, "section {i} xml:id changed AFTER copy/free: {p:?} -> {q:?}");
+    assert_eq!(
+      p, q,
+      "section {i} xml:id changed AFTER copy/free: {p:?} -> {q:?}"
+    );
   }
 }
 
@@ -303,7 +311,10 @@ fn xml_copy_node_pair_with_split_preamble() {
     let c1 = xmlCopyNode(sections[0].node_ptr(), 1);
     assert!(!c1.is_null(), "first copy returned NULL");
     let c2 = xmlCopyNode(sections[1].node_ptr(), 1);
-    assert!(!c2.is_null(), "SECOND copy returned NULL — repro of oxide bug");
+    assert!(
+      !c2.is_null(),
+      "SECOND copy returned NULL — repro of oxide bug"
+    );
     xmlFreeNode(c1);
     xmlFreeNode(c2);
   }
@@ -356,9 +367,7 @@ fn xml_copy_node_pair_with_intermediate_xpath_on_source() {
   let _p = root
     .findnodes(".//processing-instruction('latexml')")
     .unwrap_or_default();
-  let _i = root
-    .findnodes("//*[@xml:id]")
-    .unwrap_or_default();
+  let _i = root.findnodes("//*[@xml:id]").unwrap_or_default();
 
   unsafe {
     let c2 = xmlCopyNode(sections[1].node_ptr(), 1);
@@ -376,7 +385,9 @@ fn xml_copy_node_pair_with_intermediate_xpath_on_source() {
 /// Document via Document::new_ptr (mirroring what libxml-rs's higher-
 /// level callers do) + run XPath on the subdoc + run XPath on source.
 fn xml_copy_node_pair_full_oxide_style() {
-  use libxml::bindings::{xmlCopyNode, xmlNewDoc, xmlDocSetRootElement, xmlSetTreeDoc, xmlReconciliateNs};
+  use libxml::bindings::{
+    xmlCopyNode, xmlDocSetRootElement, xmlNewDoc, xmlReconciliateNs, xmlSetTreeDoc,
+  };
   let path = "tests/resources/large_doc.xml";
   if std::fs::metadata(path).is_err() {
     return;
@@ -417,7 +428,9 @@ fn xml_copy_node_pair_full_oxide_style() {
       Document::new_ptr(doc_ptr)
     };
     // Mirror PostDocument::new_document post-dup work:
-    let _id_walk = sub.get_root_element().unwrap()
+    let _id_walk = sub
+      .get_root_element()
+      .unwrap()
       .findnodes("//*[@xml:id]")
       .unwrap_or_default();
     let _src_pis = root
@@ -442,8 +455,7 @@ fn xml_copy_node_pair_full_oxide_style() {
 /// document shape.
 fn xml_copy_node_pair_nodict_parse() {
   use libxml::bindings::{
-    xmlCopyNode, xmlFreeDoc, xmlFreeNode, xmlReadMemory,
-    xmlParserOption_XML_PARSE_NODICT,
+    xmlCopyNode, xmlFreeDoc, xmlFreeNode, xmlParserOption_XML_PARSE_NODICT, xmlReadMemory,
   };
   let path = "tests/resources/large_doc.xml";
   if std::fs::metadata(path).is_err() {

--- a/tests/xpath_tests.rs
+++ b/tests/xpath_tests.rs
@@ -31,15 +31,21 @@ fn xpath_with_namespaces() {
 
   let doc = doc_result.unwrap();
   let context = Context::new(&doc).unwrap();
-  assert!(context
-    .register_namespace("h", "http://example.com/ns/hello")
-    .is_ok());
-  assert!(context
-    .register_namespace("f", "http://example.com/ns/farewell")
-    .is_ok());
-  assert!(context
-    .register_namespace("r", "http://example.com/ns/root")
-    .is_ok());
+  assert!(
+    context
+      .register_namespace("h", "http://example.com/ns/hello")
+      .is_ok()
+  );
+  assert!(
+    context
+      .register_namespace("f", "http://example.com/ns/farewell")
+      .is_ok()
+  );
+  assert!(
+    context
+      .register_namespace("r", "http://example.com/ns/root")
+      .is_ok()
+  );
   let result_h_td = context.evaluate("//h:td").unwrap();
   assert_eq!(result_h_td.get_number_of_nodes(), 3);
   assert_eq!(result_h_td.get_nodes_as_vec().len(), 3);
@@ -200,20 +206,27 @@ fn xpath_find_string_values() {
   assert!(doc_result.is_ok());
   let doc = doc_result.unwrap();
   let mut xpath = libxml::xpath::Context::new(&doc).unwrap();
-  match doc.get_root_element() { Some(root) => {
-    let tests = root.get_child_elements();
-    let empty_test = &tests[0];
-    let ids_test = &tests[1];
-    let empty_values = xpath.findvalues(".//@xml:id", Some(empty_test));
-    assert_eq!(empty_values, Ok(Vec::new()));
-    let ids_values = xpath.findvalues(".//@xml:id", Some(ids_test));
-    let expected_ids = Ok(vec![String::from("start"),String::from("mid"),String::from("end")]);
-    assert_eq!(ids_values, expected_ids);
-    let node_ids_values = ids_test.findvalues(".//@xml:id");
-    assert_eq!(node_ids_values, expected_ids);
-  } _ => {
-    panic!("Document fails to obtain root!");
-  }}
+  match doc.get_root_element() {
+    Some(root) => {
+      let tests = root.get_child_elements();
+      let empty_test = &tests[0];
+      let ids_test = &tests[1];
+      let empty_values = xpath.findvalues(".//@xml:id", Some(empty_test));
+      assert_eq!(empty_values, Ok(Vec::new()));
+      let ids_values = xpath.findvalues(".//@xml:id", Some(ids_test));
+      let expected_ids = Ok(vec![
+        String::from("start"),
+        String::from("mid"),
+        String::from("end"),
+      ]);
+      assert_eq!(ids_values, expected_ids);
+      let node_ids_values = ids_test.findvalues(".//@xml:id");
+      assert_eq!(node_ids_values, expected_ids);
+    }
+    _ => {
+      panic!("Document fails to obtain root!");
+    }
+  }
 }
 
 /// Tests for checking xpath well-formedness


### PR DESCRIPTION
Consolidates the `perf-improvements` work for a **0.3.15** release. Downstream
(latexml-oxide) currently pins this branch by git; releasing lets it drop the
branch pin for a version pin.

## Added

- **`reader::TextReader`** — safe wrapper over libxml2's `xmlTextReader` pull
  parser, for processing very large documents one subtree at a time instead of
  building the whole DOM (a 600 MB file becomes a ~7 GB tree). `from_file`,
  `read`/`read_next`, `node_type`/`is_element`/`depth`/`local_name`/
  `namespace_uri`, `read_to_next(pred)` (the streamable downward-name XPath
  subset), and two subtree accessors: `expand()` (borrowed `RoNode`, zero-copy,
  valid until the next advance) and `expand_to_document()` (an **owned**,
  self-contained `Document` copy with namespaces reconciled onto the detached
  root via `xmlDOMWrapCloneNode` + `xmlReconciliateNs`, so serialization keeps
  the `xmlns=` declarations and nothing dangles into the source).
- **`xpath::XPathError` + checked evaluators** `evaluate_checked`,
  `node_evaluate_checked`, `node_evaluate_readonly_checked` →
  `Result<Object, XPathError>`. libxml2 aborts a `//X[predicate]` evaluation
  (returning NULL) once it materializes more than `XPATH_MAX_NODESET_LENGTH`
  (10M) intermediate nodes — the *"growing nodeset hit limit"* — and the thin
  wrappers collapsed that into a bare `Err(())`. The checked variants snapshot
  libxml2's structured error (message/code/domain, with `is_nodeset_limit()`).
  The existing `evaluate`/`node_evaluate`/`node_evaluate_readonly` are
  unchanged (reimplemented as `*_checked(..).map_err(|_| ())`).

## Perf

- **Node-cache FxHash hasher** — the per-document `xmlNodePtr -> Node` cache
  hashes pointer keys with a small FxHash-style hasher instead of SipHash
  `RandomState`. Keys are non-adversarial allocator pointers; the map is never
  iterated. Dependency-free, behavior identical. ~28–30% wall reduction on
  node-heavy XML (large math documents).
- **`get_properties`/`get_properties_ns`** read each attribute's value directly
  from the attr node in hand (`xmlNodeGetContent`) instead of re-resolving by
  name (`xmlGetProp`), which re-scanned the whole attr list + allocated a name
  `CString` per attribute (quadratic in attribute count). Same returned map.

## Fixed (SIGSEGV hardening — both bypassed `catch_unwind`)

- **NULL-guarded the raw-pointer field accessors** in `c_helpers` (e.g.
  `xmlNodeType` reading `.type_` at offset 8): a NULL `xmlNodePtr` reaching an
  accessor produced `segfault at 8`. Accessors now return a benign default for
  NULL.
- **Hardened the `CStr::from_ptr` surface** in `tree::document` against
  `strlen(NULL)`: when libxml2 returns a NULL buffer (e.g. OOM during XSLT
  serialization of a huge document) the wrappers yield an empty string instead
  of dereferencing NULL (`segfault at 0 in libc`).

## Notes

- CHANGELOG `[Unreleased]` documents all of the above.
- fmt clean; clippy clean in our source (only pre-existing generated-`bindings.rs`
  warnings remain); lib tests green.
- Final commit is a no-behavior-change refactor deduplicating the checked
  evaluators and the reader advance/expand helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)