### PR TITLE
docs(msrv): declare rust-version = 1.88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 
 ### Changed
 
+* **Minimum supported Rust version is now 1.88** (declared via `rust-version`).
+  The streaming `reader` uses a let-chain (stabilized in 1.88); the edition is
+  already 2024. Consumers on 1.85–1.87 that built 0.3.14 will need to update.
 * `Node::_wrap`'s per-document `xmlNodePtr -> Node` cache now hashes pointer keys
   with a small FxHash-style hasher instead of the default SipHash `RandomState`.
   The cache is probed on every `Node` wrap (child/sibling walks, XPath results,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "libxml"
 version = "0.3.15"
 edition = "2024"
+rust-version = "1.88"
 authors = ["Andreas Franzén <andreas@devil.se>", "Deyan Ginev <deyan.ginev@gmail.com>","Jan Frederik Schaefer <j.schaefer@jacobs-university.de>"]
 description = "A Rust wrapper for libxml2 - the XML C parser and toolkit developed for the Gnome project"
 repository = "https://github.com/KWARC/rust-libxml"


### PR DESCRIPTION
0.3.15's streaming `reader` uses a let-chain (stabilized in Rust 1.88), so the effective MSRV is 1.88 even though edition 2024 alone needs only 1.85. Declare `rust-version = "1.88"` so cargo gives consumers a clean version error rather than a raw syntax error, and note the MSRV bump in the CHANGELOG [0.3.15] section. No code change. (CI is stable-only, so it did not catch the bump.)

Intended to land before publishing 0.3.15; the `v0.3.15` tag will move onto the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)