### PR TITLE
vcpkg: link Windows SDK system libs (bcrypt, ws2_32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [0.3.16] (2026-07-12)
+
+### Fixed
+
+* Windows/MSVC vcpkg builds: emit `cargo:rustc-link-lib=bcrypt` and `ws2_32`
+  alongside the vcpkg-resolved libraries. vcpkg emits link directives for the
+  port's libraries and port dependencies but not for Windows SDK system
+  libraries (`Libs.private` in `libxml-2.0.pc`); libxml2 >= 2.12 calls
+  `BCryptGenRandom` from `xmlInitRandom`, so linking a static `libxml2.lib`
+  into any real target (proc-macro dylib, bin, test) failed with LNK2019.
+  Both import libraries ship with every MSVC/Windows SDK toolchain.
+
 ## [0.3.15] (2026-07-06)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libxml"
-version = "0.3.15"
+version = "0.3.16"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Andreas Franzén <andreas@devil.se>", "Deyan Ginev <deyan.ginev@gmail.com>","Jan Frederik Schaefer <j.schaefer@jacobs-university.de>"]

--- a/build.rs
+++ b/build.rs
@@ -138,6 +138,17 @@ mod vcpkg_dep {
   use crate::ProbedLib;
   pub fn vcpkg_find_libxml2() -> Option<ProbedLib> {
     if let Ok(metadata) = vcpkg::Config::new().find_package("libxml2") {
+      // vcpkg emits link directives for the port's own libraries and its
+      // port dependencies (iconv, zlib, ...), but NOT for Windows SDK
+      // system libraries, which are Libs.private in libxml-2.0.pc:
+      // libxml2 >= 2.12 calls BCryptGenRandom (xmlInitRandom, dict.c), so
+      // a static libxml2.lib leaves that symbol unresolved unless we link
+      // bcrypt ourselves. ws2_32 likewise backs the (default-on) nanohttp
+      // code. Both import libraries ship with every MSVC/Windows SDK
+      // toolchain, so linking them unconditionally here is safe even for
+      // vcpkg builds configured without those features.
+      println!("cargo:rustc-link-lib=bcrypt");
+      println!("cargo:rustc-link-lib=ws2_32");
       let include_paths = metadata
         .include_paths
         .into_iter()


### PR DESCRIPTION
The vcpkg arm emits link directives for the port's libraries and port dependencies, but not for Windows SDK system libraries (`Libs.private` in `libxml-2.0.pc`). libxml2 >= 2.12 calls `BCryptGenRandom` from `xmlInitRandom`, so linking the static `libxml2.lib` into any real target (proc-macro dylib, bin, test) fails with LNK2019; `ws2_32` likewise backs nanohttp. Both import libraries ship with every MSVC toolchain, so linking them unconditionally in the vcpkg arm is safe.

Witnessed in latexml-oxide's Windows port (first surfaced in a proc-macro dylib link, since `cargo check` of rlibs never links).