### PR TITLE
fix(windows): 0.3.18 MSVC link failure — xmlFree is not a linkable symbol there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [0.3.19] (2026-08-01)
+
+### Fixed
+
+* Windows/MSVC link failure in 0.3.18 (`LNK2019: unresolved external symbol
+  xmlFree`): the `expand_to_document` prefix-restoration freed the minted
+  prefix through the `xmlFree` global, which is not a linkable data symbol on
+  MSVC builds. It now goes through `c_helpers::bindgenFree`, the crate's
+  existing per-target free shim. Any consumer LINKING 0.3.18 on
+  `windows-msvc` fails; `cargo check` passes (no link step), which is how it
+  escaped. 0.3.18 is yanked.
+
 ## [0.3.18] (2026-07-31)
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libxml"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Andreas Franzén <andreas@devil.se>", "Deyan Ginev <deyan.ginev@gmail.com>","Jan Frederik Schaefer <j.schaefer@jacobs-university.de>"]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -316,9 +316,10 @@ impl TextReader {
               } else {
                 xmlStrdup(want)
               };
-              if let Some(xml_free_fn) = xmlFree {
-                xml_free_fn(old);
-              }
+              // Portable free: on MSVC `xmlFree` is not a linkable data
+              // symbol (LNK2019 in 0.3.18); `bindgenFree` carries the
+              // per-target arm the crate already uses elsewhere.
+              crate::c_helpers::bindgenFree(old);
             }
           }
         }


### PR DESCRIPTION
0.3.18's `expand_to_document` prefix-restoration frees through the `xmlFree` global, which MSVC builds do not expose as a linkable data symbol → `LNK2019` for any consumer that LINKS the crate on `windows-msvc` (`cargo check` passes, no link step — how it escaped). Fixed by routing through `c_helpers::bindgenFree`, the crate's existing per-target free shim. 0.3.19; 0.3.18 will be yanked after this lands.

**Waiting for the Windows CI lane before merge this time.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)