### PR TITLE
Node::set_linked is public — leak-free teardown for doc-owned handle caches (0.3.20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [0.3.20] (2026-08-02)
+
+### Changed
+
+* `Node::set_linked` is now public. A consumer holding long-lived `Node`
+  handles into a document (id caches) needs to declare "the document owns
+  this memory" before dropping handles that intermediate processing may have
+  `unlink_node`ed — without it, the only safe teardown was to leak each
+  wrapper's allocation (~100+ bytes per handle per document; a leading
+  retention term across a 115,000-page render downstream).
+
 ## [0.3.19] (2026-08-01)
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libxml"
-version = "0.3.19"
+version = "0.3.20"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Andreas Franzén <andreas@devil.se>", "Deyan Ginev <deyan.ginev@gmail.com>","Jan Frederik Schaefer <j.schaefer@jacobs-university.de>"]

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1305,7 +1305,15 @@ impl Node {
   /// wrapper's `Drop` will free it again). There is no public path to
   /// untake ownership; the right fix is for the caller to never re-link
   /// a `RustOwned` node.
-  pub(crate) fn set_linked(&self) {
+  ///
+  /// Public since 0.3.20: a consumer holding long-lived `Node` handles into a
+  /// document (id caches and the like) needs to declare "the document owns
+  /// this memory" before dropping the handles — some of which may have been
+  /// `unlink_node`ed by intermediate processing. Without this, the only safe
+  /// teardown was to leak each wrapper's allocation (latexml-oxide's
+  /// `DocOwnedNode`, ~100+ bytes per id-cache entry per document — measured
+  /// as a leading retention term at ~150 KB/page across a 115k-page render).
+  pub fn set_linked(&self) {
     let mut inner = self.0.borrow_mut();
     debug_assert!(
       !matches!(inner.linkage, Linkage::RustOwned),


### PR DESCRIPTION
The `Drop` contract fires `xmlFreeNode` for `Unlinked` wrappers, so a consumer holding long-lived handles (id caches) whose nodes were `unlink_node`ed by intermediate processing had no safe teardown except leaking each wrapper's allocation — latexml-oxide's `DocOwnedNode` workaround, measured as a leading retention term (~150 KB/page) across a 115,000-page render. `set_linked` (existing crate-internal API, documented double-free guard intact) lets the consumer declare document ownership before drop. Version 0.3.20.

Windows CI lane will be verified green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)